### PR TITLE
Feat/image lifecycle management

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,18 +78,22 @@ my_ml_service/
 
 Copy `env.sample.json` to `env.json` and fill in your GCP project, bucket, service accounts, etc. See the [configuration guide](docs/route-guide.md).
 
-### 3. Create GCP infrastructure
+### 3. Create infrastructure
 
 ```bash
-aigear-gcp-infra --create
+aigear-infra --create
 ```
 
 ### 4. Generate env schema (optional)
 
 ```bash
 aigear-env-schema --generate
-# Force regenerate
+# Force regenerate after env.json changes
 aigear-env-schema --generate --force
+# Show current schema
+aigear-env-schema --show
+# Delete schema
+aigear-env-schema --delete
 ```
 
 Auto-generates a Pydantic model from your `env.json`. This gives you full type hints and IDE auto-complete when reading configuration, so you can navigate from any variable directly back to its definition in `env.json` instead of looking up string keys manually.
@@ -186,12 +190,12 @@ See the full [CLI Reference](docs/cli-reference.md) for all commands and argumen
 | Command | Description |
 |---|---|
 | `aigear-init` | Initialize a new project scaffold |
-| `aigear-gcp-infra` | Provision or tear down GCP infrastructure (buckets, IAM, Pub/Sub, Cloud Build, etc.) |
+| `aigear-infra` | Provision or tear down infrastructure (buckets, IAM, Pub/Sub, Cloud Build, etc.) |
 | `aigear-task` | Run a pipeline step (`workflow`) or start a gRPC model server (`grpc`) |
 | `aigear-scheduler` | Manage Cloud Scheduler jobs (create / update / delete / run / pause / resume) |
 | `aigear-image` | Build and/or push Docker images to Artifact Registry |
 | `aigear-model` | Generate YAML and manage the full lifecycle of a gRPC model service (deploy, update, delete, status) |
-| `aigear-env-schema` | Auto-generate a Pydantic schema from `env.json` |
+| `aigear-env-schema` | Generate, delete, or show the Pydantic schema derived from `env.json` |
 | `aigear-kms-env` | Encrypt or decrypt `env.json` using Cloud KMS |
 
 ---

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -5,7 +5,7 @@ All CLI entry points are installed as standalone commands by `pip install aigear
 | Command | Description |
 |---|---|
 | `aigear-init` | Initialize a new project scaffold |
-| `aigear-gcp-infra` | Create GCP infrastructure (buckets, IAM, Pub/Sub, schedulers) |
+| `aigear-infra` | Create infrastructure (buckets, IAM, Pub/Sub, schedulers) |
 | `aigear-task` | Run a pipeline step or start a gRPC model service |
 | `aigear-scheduler` | Create a Cloud Scheduler job for pipeline steps |
 | `aigear-image` | Build and optionally push Docker images to Artifact Registry |
@@ -261,18 +261,18 @@ aigear-model --version logistic_regression --local --delete
 
 ### `aigear-env-schema`
 
-Auto-generate a Pydantic schema file from the current `env.json`.
+Manage the lifecycle of the Pydantic schema file generated from `env.json`.
 
 ```
-aigear-env-schema [--generate] [--force]
+aigear-env-schema {--generate | --delete | --show} [--force]
 ```
 
 | Argument | Description |
 |---|---|
-| `--generate` | Generate environment schema file. Runs by default if omitted. |
-| `--force` | Regenerate the schema even if one already exists |
-
-> Future commands: `--delete`, `--update`
+| `--generate` | Generate environment schema file from `env.json` |
+| `--delete` | Delete the generated schema file |
+| `--show` | Print the current schema file content |
+| `--force` | Force regenerate even if the schema already exists (used with `--generate`) |
 
 ---
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -144,26 +144,58 @@ aigear-scheduler --resume --version logistic_regression
 
 ### `aigear-image`
 
-Build Docker images for the pipeline (`Dockerfile.pl`) and/or model service (`Dockerfile.ms`), and optionally push to Artifact Registry.
+Manage the full lifecycle of Docker images for the pipeline (`Dockerfile.pl`) and model service (`Dockerfile.ms`): build, delete, or re-tag locally and optionally sync to Artifact Registry.
 
 ```
-aigear-image [--create]
+aigear-image {--create | --delete | --retag}
+             [--push]
              [--dockerfile_path PATH] [--build_context DIR]
-             [--image_name NAME] [--image_version TAG]
-             [--is_service] [--force] [--push]
+             [--is_service] [--all]
+             [--src_tag TAG] [--target_tag TAG]
 ```
 
-At least one of `--create` or `--push` is required. They can be combined to build then push in a single command.
+One action (`--create`, `--delete`, `--retag`) is required. `--push` syncs the operation to Artifact Registry after the local step succeeds.
+
+**Actions (mutually exclusive)**
+
+| Argument | Description |
+|---|---|
+| `--create` | Build the Docker image locally |
+| `--delete` | Remove the Docker image locally |
+| `--retag` | Tag an existing local image with a new tag (requires `--src_tag` and `--target_tag`) |
+
+**Scope modifiers**
 
 | Argument | Default | Description |
 |---|---|---|
-| `--create` | — | Build the Docker image(s) |
-| `--push` | — | Push the Docker image(s) to Artifact Registry. Can be used alone (push-only) or together with `--create` (build then push). |
-| `--dockerfile_path` | `None` | Path to a specific Dockerfile. If omitted, operates on both `Dockerfile.pl` and `Dockerfile.ms` |
-| `--build_context` | `.` | Docker build context directory |
-| `--is_service` | `false` | Mark image as a model service image (auto-set when building `Dockerfile.ms`) |
+| `--all` | `false` | Operate on both `Dockerfile.pl` (pipeline) and `Dockerfile.ms` (service) in one command |
+| `--dockerfile_path` | `None` | Path to a specific Dockerfile. `Dockerfile.ms` automatically implies `--is_service`; `Dockerfile.pl` implies pipeline |
+| `--is_service` | `false` | Target the model service image. Ignored when `--dockerfile_path` is `Dockerfile.pl` or `Dockerfile.ms` (inferred automatically) |
+| `--build_context` | `.` | Docker build context directory (used with `--create`) |
 
-> Future commands: `--delete`, `--update`
+**Remote sync**
+
+| Argument | Description |
+|---|---|
+| `--push` | After the local operation succeeds, sync to Artifact Registry (push image, delete remote tag, or add remote tag) |
+
+**Re-tag arguments**
+
+| Argument | Description |
+|---|---|
+| `--src_tag` | Source tag (required with `--retag`) |
+| `--target_tag` | Destination tag (required with `--retag`) |
+
+**Scope resolution (without `--all`)**
+
+| `--dockerfile_path` | `--is_service` | Target |
+|---|---|---|
+| `Dockerfile.ms` | any | service image |
+| `Dockerfile.pl` | any | pipeline image |
+| custom path | `false` (default) | pipeline image |
+| custom path | `true` | service image |
+| omitted | `false` (default) | pipeline image |
+| omitted | `true` | service image |
 
 ---
 

--- a/docs/route-guide.md
+++ b/docs/route-guide.md
@@ -338,8 +338,8 @@ All CLI commands read `env.json` from the current working directory.
 | Command | Arguments | Description |
 | :--- | :--- | :--- |
 | `aigear-init` | `--name`, `--pipeline_versions` | Scaffold a new project |
-| `aigear-gcp-infra` | `--create`, `--update`, `--delete`, `--status` | Provision, update, tear down, or query all GCP infrastructure defined in `env.json` |
-| `aigear-env-schema` | `--generate`, `--force` | Auto-generate a Pydantic schema from `env.json` |
+| `aigear-infra` | `--create`, `--update`, `--delete`, `--status` | Provision, update, tear down, or query all infrastructure defined in `env.json` |
+| `aigear-env-schema` | `--generate`, `--delete`, `--show`, `--force` | Manage the lifecycle of the Pydantic schema generated from `env.json` |
 | `aigear-kms-env` | `--encrypt`, `--decrypt`, `--environment`, `--input`, `--output`, `--project-id`, `--location`, `--keyring`, `--key` | Encrypt or decrypt `env.json` using Cloud KMS |
 | `aigear-image` | `--create`, `--delete`, `--retag`, `--push`, `--all`, `--dockerfile_path`, `--build_context`, `--is_service`, `--src_tag`, `--target_tag` | Build, delete, or re-tag Docker images; optionally sync to Artifact Registry |
 | `aigear-scheduler` | `--create`, `--update`, `--delete`, `--status`, `--list`, `--run`, `--pause`, `--resume`, `--version`, `--step_names` | Manage Cloud Scheduler jobs for pipeline steps |

--- a/docs/route-guide.md
+++ b/docs/route-guide.md
@@ -341,7 +341,7 @@ All CLI commands read `env.json` from the current working directory.
 | `aigear-gcp-infra` | `--create`, `--update`, `--delete`, `--status` | Provision, update, tear down, or query all GCP infrastructure defined in `env.json` |
 | `aigear-env-schema` | `--generate`, `--force` | Auto-generate a Pydantic schema from `env.json` |
 | `aigear-kms-env` | `--encrypt`, `--decrypt`, `--environment`, `--input`, `--output`, `--project-id`, `--location`, `--keyring`, `--key` | Encrypt or decrypt `env.json` using Cloud KMS |
-| `aigear-image` | `--create`, `--push`, `--dockerfile_path`, `--build_context`, `--is_service` | Build and/or push Docker images to Artifact Registry |
+| `aigear-image` | `--create`, `--delete`, `--retag`, `--push`, `--all`, `--dockerfile_path`, `--build_context`, `--is_service`, `--src_tag`, `--target_tag` | Build, delete, or re-tag Docker images; optionally sync to Artifact Registry |
 | `aigear-scheduler` | `--create`, `--update`, `--delete`, `--status`, `--list`, `--run`, `--pause`, `--resume`, `--version`, `--step_names` | Manage Cloud Scheduler jobs for pipeline steps |
 | `aigear-task workflow` | `--version`, `--step` | Run a single pipeline step locally (step name looked up from `env.json`) |
 | `aigear-task grpc` | `--version` | Start a gRPC model serving server (model class path read from `env.json`) |

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -494,8 +494,8 @@ scikit_learn==1.8.0
 Build both images:
 
 ```bash
-# Build locally (no push)
-aigear-image --create
+# Build both images locally (no push)
+aigear-image --create --all
 ```
 
 > **Local build:** Make sure `gcs_switch = False` in `src/pipelines/common/constant.py`. When running locally, files are stored under `asset/` instead of GCS.
@@ -643,7 +643,7 @@ src/pipelines/logistic_regression/model_service/
 Once the pipeline has been validated locally and the YAML files have been generated (Step 9), push the images to GCP Artifact Registry:
 
 ```bash
-aigear-image --create --push
+aigear-image --create --push --all
 ```
 
 > **Before pushing to GCP:** Make sure `gcs_switch = True` in `src/pipelines/common/constant.py`. Pipeline steps running on GCP need to read and write files via GCS.
@@ -682,7 +682,7 @@ aigear-gcp-infra --create
 
 # ── Step 6: Build Docker images locally ───────────────────────────────────────
 # Requires: gcs_switch = False in src/pipelines/common/constant.py
-aigear-image --create
+aigear-image --create --all
 
 # ── Step 7: Run pipeline and model service locally (Docker Compose) ───────────
 # Option A (default): build fresh image from Dockerfile on every run
@@ -715,7 +715,7 @@ aigear-model --version logistic_regression --production --yaml
 
 # ── Step 10: Push images to Artifact Registry (YAML baked in) ─────────────────
 # Requires: gcs_switch = True in src/pipelines/common/constant.py
-aigear-image --create --push
+aigear-image --create --push --all
 
 # ── Step 11: Schedule recurring pipeline runs on GCP ──────────────────────────
 aigear-scheduler --create \

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -187,6 +187,10 @@ Auto-generate a typed Pydantic schema from your `env.json` so all pipeline code 
 aigear-env-schema --generate
 # Force regenerate after env.json changes
 aigear-env-schema --generate --force
+# Show current schema content
+aigear-env-schema --show
+# Delete schema
+aigear-env-schema --delete
 ```
 
 This writes a schema to `config_schema/env_schema.py`. Every pipeline step imports it:
@@ -674,8 +678,8 @@ cp env.sample.json env.json
 # ── Step 3: Generate typed config schema ──────────────────────────────────────
 aigear-env-schema --generate
 
-# ── Step 4: Provision GCP infrastructure (owner-level access required) ────────
-aigear-gcp-infra --create
+# ── Step 4: Provision infrastructure (owner-level access required) ────────────
+aigear-infra --create
 
 # ── Step 5: Implement pipeline code ───────────────────────────────────────────
 # Fill in src/pipelines/logistic_regression/{fetch_data,preprocessing,training,model_service}/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dev = [
 
 [project.scripts]
 aigear-init = "aigear.cli.project_cli:project_init"
-aigear-gcp-infra = "aigear.cli.gcp_cli:gcp_infra"
+aigear-infra = "aigear.cli.gcp_cli:gcp_infra"
 aigear-env-schema = "aigear.cli.env_schema:env_schema"
 aigear-image = "aigear.cli.artifacts_image:docker_image"
 aigear-scheduler = "aigear.cli.gcp_scheduler:gcp_scheduler"

--- a/src/aigear/cli/artifacts_image.py
+++ b/src/aigear/cli/artifacts_image.py
@@ -1,85 +1,102 @@
 import argparse
 
 from aigear.common.constant import DOCKERFILE_PIPELINE, DOCKERFILE_SERVICE
-from aigear.deploy.gcp.artifacts_image import create_artifacts_image
+from aigear.deploy.gcp.artifacts_image import (
+    create_artifacts_image,
+    delete_artifacts_image,
+    retag_artifacts_image,
+    prune_artifacts_image,
+)
 
 
 def get_argument() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
-    group = parser.add_mutually_exclusive_group(required=False)
-    group.add_argument(
-        "--create",
-        action="store_true",
-        help="Build Docker image(s).",
-    )
-    # Future commands:
-    # group.add_argument("--delete", action="store_true", help="...")
-    # group.add_argument("--update", action="store_true", help="...")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--create", action="store_true", help="Build Docker image(s) locally.")
+    group.add_argument("--delete", action="store_true", help="Delete Docker image(s).")
+    group.add_argument("--retag", action="store_true", help="Re-tag a Docker image.")
+    group.add_argument("--prune", action="store_true", help="Remove old tags, keeping the latest N.")
     parser.add_argument(
         "--push",
         action="store_true",
-        help="Push Docker image(s). Can be used alone (push only) or with --create (build then push).",
+        help="Sync the operation to Artifact Registry.",
     )
     parser.add_argument(
         "--dockerfile_path",
         default=None,
-        help="Path of Dockerfile. If omitted, operates on all default images.",
+        help="Path of Dockerfile. If omitted with --create, operates on all default images.",
     )
-    parser.add_argument(
-        "--build_context", default=".", help="Docker build context path."
-    )
+    parser.add_argument("--build_context", default=".", help="Docker build context path.")
     parser.add_argument(
         "--is_service",
         action="store_true",
-        help="Determine whether it is a model service image.",
+        help="Target the model service image (default: pipeline image).",
     )
+    parser.add_argument("--src_tag", default=None, help="Source tag for --retag.")
+    parser.add_argument("--target_tag", default=None, help="Destination tag for --retag.")
+    parser.add_argument("--keep", type=int, default=None, help="Tags to retain for --prune (>= 1).")
+
     args = parser.parse_args()
-    if not args.create and not args.push:
-        parser.error("At least one of --create or --push is required.")
+
+    if args.retag and args.src_tag is None:
+        parser.error("--retag requires --src_tag.")
+    if args.retag and args.target_tag is None:
+        parser.error("--retag requires --target_tag.")
+    if args.prune and args.keep is None:
+        parser.error("--prune requires --keep N.")
+    if args.prune and args.keep < 1:
+        parser.error("--keep must be >= 1.")
+
     return args
 
 
-def _run_images(args: argparse.Namespace) -> None:
-    if args.dockerfile_path is None:
+def _run_operation(args: argparse.Namespace, dockerfile_path=None, is_service=False) -> bool:
+    if args.create:
+        return create_artifacts_image(
+            dockerfile_path=dockerfile_path,
+            build_context=args.build_context,
+            is_service=is_service,
+            is_build=True,
+            is_push=args.push,
+        )
+    if args.delete:
+        return delete_artifacts_image(is_service=is_service, is_push=args.push)
+    if args.retag:
+        return retag_artifacts_image(
+            src_tag=args.src_tag,
+            target_tag=args.target_tag,
+            is_service=is_service,
+            is_push=args.push,
+        )
+    if args.prune:
+        return prune_artifacts_image(keep=args.keep, is_service=is_service, is_push=args.push)
+    return False
+
+
+def docker_image():
+    args = get_argument()
+
+    if args.create and args.dockerfile_path is None:
         print("No '--dockerfile_path' provided, operating on all default images.")
         for dockerfile, is_service in [
             (DOCKERFILE_PIPELINE, False),
             (DOCKERFILE_SERVICE, True),
         ]:
             print(f"Processing image: '{dockerfile}'...")
-            success = create_artifacts_image(
-                dockerfile_path=dockerfile,
-                build_context=args.build_context,
-                is_service=is_service,
-                is_build=args.create,
-                is_push=args.push,
-            )
+            success = _run_operation(args, dockerfile_path=dockerfile, is_service=is_service)
             if success:
                 print(f"The image({dockerfile}) operation completed.")
             else:
-                print(
-                    f"The image({dockerfile}) operation failed, please check the errors above."
-                )
+                print(f"The image({dockerfile}) operation failed, please check the errors above.")
             print("-----------------------------------")
     else:
-        print(f"Processing image: '{args.dockerfile_path}'...")
-        success = create_artifacts_image(
-            dockerfile_path=args.dockerfile_path,
-            build_context=args.build_context,
-            is_service=args.is_service,
-            is_build=args.create,
-            is_push=args.push,
-        )
+        label = args.dockerfile_path or ("service" if args.is_service else "pipeline")
+        print(f"Processing image: '{label}'...")
+        success = _run_operation(args, dockerfile_path=args.dockerfile_path, is_service=args.is_service)
         if success:
-            print(f"The image({args.dockerfile_path}) operation completed.")
+            print(f"The image({label}) operation completed.")
         else:
-            print(
-                f"The image({args.dockerfile_path}) operation failed, please check the errors above."
-            )
+            print(f"The image({label}) operation failed, please check the errors above.")
         print("-----------------------------------")
-
-
-def docker_image():
-    _run_images(get_argument())

--- a/src/aigear/cli/artifacts_image.py
+++ b/src/aigear/cli/artifacts_image.py
@@ -85,7 +85,13 @@ def docker_image():
     if args.all:
         targets = [(DOCKERFILE_PIPELINE, False), (DOCKERFILE_SERVICE, True)]
     elif args.dockerfile_path:
-        targets = [(args.dockerfile_path, args.is_service)]
+        if args.dockerfile_path == DOCKERFILE_SERVICE:
+            is_service = True
+        elif args.dockerfile_path == DOCKERFILE_PIPELINE:
+            is_service = False
+        else:
+            is_service = args.is_service
+        targets = [(args.dockerfile_path, is_service)]
     else:
         targets = [(None, args.is_service)]
 

--- a/src/aigear/cli/artifacts_image.py
+++ b/src/aigear/cli/artifacts_image.py
@@ -36,6 +36,11 @@ def get_argument() -> argparse.Namespace:
         action="store_true",
         help="Target the model service image (default: pipeline image).",
     )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Operate on both pipeline and service images.",
+    )
     parser.add_argument("--src_tag", default=None, help="Source tag for --retag.")
     parser.add_argument(
         "--target_tag", default=None, help="Destination tag for --retag."
@@ -77,28 +82,18 @@ def _run_operation(
 def docker_image():
     args = get_argument()
 
-    if args.create and args.dockerfile_path is None:
-        print("No '--dockerfile_path' provided, operating on all default images.")
-        for dockerfile, is_service in [
-            (DOCKERFILE_PIPELINE, False),
-            (DOCKERFILE_SERVICE, True),
-        ]:
-            print(f"Processing image: '{dockerfile}'...")
-            success = _run_operation(
-                args, dockerfile_path=dockerfile, is_service=is_service
-            )
-            if success:
-                print(f"The image({dockerfile}) operation completed.")
-            else:
-                print(
-                    f"The image({dockerfile}) operation failed, please check the errors above."
-                )
-            print("-----------------------------------")
+    if args.all:
+        targets = [(DOCKERFILE_PIPELINE, False), (DOCKERFILE_SERVICE, True)]
+    elif args.dockerfile_path:
+        targets = [(args.dockerfile_path, args.is_service)]
     else:
-        label = args.dockerfile_path or ("service" if args.is_service else "pipeline")
+        targets = [(None, args.is_service)]
+
+    for dockerfile_path, is_service in targets:
+        label = dockerfile_path or ("service" if is_service else "pipeline")
         print(f"Processing image: '{label}'...")
         success = _run_operation(
-            args, dockerfile_path=args.dockerfile_path, is_service=args.is_service
+            args, dockerfile_path=dockerfile_path, is_service=is_service
         )
         if success:
             print(f"The image({label}) operation completed.")

--- a/src/aigear/cli/artifacts_image.py
+++ b/src/aigear/cli/artifacts_image.py
@@ -5,7 +5,6 @@ from aigear.deploy.gcp.artifacts_image import (
     create_artifacts_image,
     delete_artifacts_image,
     retag_artifacts_image,
-    prune_artifacts_image,
 )
 
 
@@ -14,10 +13,11 @@ def get_argument() -> argparse.Namespace:
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
     group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument("--create", action="store_true", help="Build Docker image(s) locally.")
+    group.add_argument(
+        "--create", action="store_true", help="Build Docker image(s) locally."
+    )
     group.add_argument("--delete", action="store_true", help="Delete Docker image(s).")
     group.add_argument("--retag", action="store_true", help="Re-tag a Docker image.")
-    group.add_argument("--prune", action="store_true", help="Remove old tags, keeping the latest N.")
     parser.add_argument(
         "--push",
         action="store_true",
@@ -28,15 +28,18 @@ def get_argument() -> argparse.Namespace:
         default=None,
         help="Path of Dockerfile. If omitted with --create, operates on all default images.",
     )
-    parser.add_argument("--build_context", default=".", help="Docker build context path.")
+    parser.add_argument(
+        "--build_context", default=".", help="Docker build context path."
+    )
     parser.add_argument(
         "--is_service",
         action="store_true",
         help="Target the model service image (default: pipeline image).",
     )
     parser.add_argument("--src_tag", default=None, help="Source tag for --retag.")
-    parser.add_argument("--target_tag", default=None, help="Destination tag for --retag.")
-    parser.add_argument("--keep", type=int, default=None, help="Tags to retain for --prune (>= 1).")
+    parser.add_argument(
+        "--target_tag", default=None, help="Destination tag for --retag."
+    )
 
     args = parser.parse_args()
 
@@ -44,15 +47,13 @@ def get_argument() -> argparse.Namespace:
         parser.error("--retag requires --src_tag.")
     if args.retag and args.target_tag is None:
         parser.error("--retag requires --target_tag.")
-    if args.prune and args.keep is None:
-        parser.error("--prune requires --keep N.")
-    if args.prune and args.keep < 1:
-        parser.error("--keep must be >= 1.")
 
     return args
 
 
-def _run_operation(args: argparse.Namespace, dockerfile_path=None, is_service=False) -> bool:
+def _run_operation(
+    args: argparse.Namespace, dockerfile_path=None, is_service=False
+) -> bool:
     if args.create:
         return create_artifacts_image(
             dockerfile_path=dockerfile_path,
@@ -70,8 +71,6 @@ def _run_operation(args: argparse.Namespace, dockerfile_path=None, is_service=Fa
             is_service=is_service,
             is_push=args.push,
         )
-    if args.prune:
-        return prune_artifacts_image(keep=args.keep, is_service=is_service, is_push=args.push)
     return False
 
 
@@ -85,18 +84,26 @@ def docker_image():
             (DOCKERFILE_SERVICE, True),
         ]:
             print(f"Processing image: '{dockerfile}'...")
-            success = _run_operation(args, dockerfile_path=dockerfile, is_service=is_service)
+            success = _run_operation(
+                args, dockerfile_path=dockerfile, is_service=is_service
+            )
             if success:
                 print(f"The image({dockerfile}) operation completed.")
             else:
-                print(f"The image({dockerfile}) operation failed, please check the errors above.")
+                print(
+                    f"The image({dockerfile}) operation failed, please check the errors above."
+                )
             print("-----------------------------------")
     else:
         label = args.dockerfile_path or ("service" if args.is_service else "pipeline")
         print(f"Processing image: '{label}'...")
-        success = _run_operation(args, dockerfile_path=args.dockerfile_path, is_service=args.is_service)
+        success = _run_operation(
+            args, dockerfile_path=args.dockerfile_path, is_service=args.is_service
+        )
         if success:
             print(f"The image({label}) operation completed.")
         else:
-            print(f"The image({label}) operation failed, please check the errors above.")
+            print(
+                f"The image({label}) operation failed, please check the errors above."
+            )
         print("-----------------------------------")

--- a/src/aigear/cli/env_schema.py
+++ b/src/aigear/cli/env_schema.py
@@ -10,9 +10,12 @@ def get_argument() -> argparse.Namespace:
     group.add_argument(
         "--generate", action="store_true", help="Generate environment schema file."
     )
-    # Future commands:
-    # group.add_argument("--delete", action="store_true", help="...")
-    # group.add_argument("--update", action="store_true", help="...")
+    group.add_argument(
+        "--delete", action="store_true", help="Delete the generated environment schema file."
+    )
+    group.add_argument(
+        "--show", action="store_true", help="Print the current environment schema file."
+    )
     parser.add_argument(
         "--force",
         action="store_true",
@@ -25,8 +28,7 @@ def env_schema() -> None:
     args = get_argument()
     if args.generate:
         EnvConfig.generative_env_schema(forced_generate=args.force)
-    # Future commands:
-    # elif args.delete:
-    #     EnvConfig.delete_env_schema()
-    # elif args.update:
-    #     EnvConfig.update_env_schema(forced_generate=args.force)
+    elif args.delete:
+        EnvConfig.delete_env_schema()
+    elif args.show:
+        EnvConfig.show_env_schema()

--- a/src/aigear/common/config.py
+++ b/src/aigear/common/config.py
@@ -137,6 +137,25 @@ class AppConfig:
             forced_generate=forced_generate,
         )
 
+    @classmethod
+    def delete_env_schema(cls) -> None:
+        """Delete the generated env schema file."""
+        output_path = Path.cwd() / "config_schema/env_schema.py"
+        if not output_path.exists():
+            logger.info(f"The 'env_schema' does not exist: {output_path}.")
+            return
+        output_path.unlink()
+        logger.info(f"Deleted 'env_schema': {output_path}.")
+
+    @classmethod
+    def show_env_schema(cls) -> None:
+        """Print the content of the generated env schema file."""
+        output_path = Path.cwd() / "config_schema/env_schema.py"
+        if not output_path.exists():
+            logger.warning(f"The 'env_schema' does not exist: {output_path}.")
+            return
+        print(output_path.read_text(encoding="utf-8"))
+
 
 # ─── Backwards-compatible aliases ────────────────────────────────────────────
 # These allow existing code that imports AigearConfig / PipelinesConfig / EnvConfig
@@ -176,6 +195,15 @@ class EnvConfig:
         logger.info("Generating env schema...")
         AppConfig.generate_env_schema(forced_generate)
         logger.info("Env schema generation complete.")
+
+    @classmethod
+    def delete_env_schema(cls) -> None:
+        logger.info("Deleting env schema...")
+        AppConfig.delete_env_schema()
+
+    @classmethod
+    def show_env_schema(cls) -> None:
+        AppConfig.show_env_schema()
 
 
 # ─── Module-level helpers (backwards compatible) ─────────────────────────────

--- a/src/aigear/deploy/gcp/artifacts_image.py
+++ b/src/aigear/deploy/gcp/artifacts_image.py
@@ -44,31 +44,6 @@ class LocalImage:
     def remove(self) -> bool:
         return run_sh_stream(["docker", "rmi", self.image_path]) == 0
 
-    def prune(self, keep: int) -> list[str]:
-        output = run_sh(
-            [
-                "docker",
-                "images",
-                "--format",
-                "{{.Tag}}\t{{.CreatedAt}}",
-                self._image_name,
-            ]
-        )
-        entries = []
-        for line in output.strip().splitlines():
-            parts = line.strip().split("\t", 1)
-            if len(parts) == 2 and parts[0] != "latest":
-                entries.append((parts[0], parts[1]))
-        entries.sort(key=lambda x: x[1], reverse=True)  # newest first
-        to_delete = entries[keep:]
-        deleted = []
-        for tag, _ in to_delete:
-            if run_sh_stream(["docker", "rmi", f"{self._image_name}:{tag}"]) == 0:
-                deleted.append(tag)
-            else:
-                logger.warning(f"Failed to remove local image tag: {tag}")
-        return deleted
-
 
 class RegistryImage:
     def __init__(self, image_path: str):
@@ -130,44 +105,6 @@ class RegistryImage:
         logger.info(result)
         return "ERROR" not in result
 
-    def prune(self, keep: int) -> list[str]:
-        output = run_sh(
-            [
-                "gcloud",
-                "artifacts",
-                "docker",
-                "images",
-                "list",
-                self._image_name,
-                "--include-tags",
-                "--sort-by=~createTime",
-                "--format=value(tags)",
-            ]
-        )
-        tags = [
-            line.strip()
-            for line in output.strip().splitlines()
-            if line.strip() and line.strip() != "latest"
-        ]
-        to_delete = tags[keep:]
-        deleted = []
-        for tag in to_delete:
-            result = run_sh(
-                [
-                    "gcloud",
-                    "artifacts",
-                    "docker",
-                    "images",
-                    "delete",
-                    f"{self._image_name}:{tag}",
-                    "--quiet",
-                ]
-            )
-            if "ERROR" not in result:
-                deleted.append(tag)
-            else:
-                logger.warning(f"Failed to delete registry tag {tag}: {result}")
-        return deleted
 
 
 def _validate_dockerfile_venvs(dockerfile_path: str, is_service: bool) -> None:
@@ -306,21 +243,3 @@ def retag_artifacts_image(
     return True
 
 
-def prune_artifacts_image(keep: int, is_service=False, is_push=False) -> bool:
-    """Returns True always (prune continues on individual failures)."""
-    log_tag = "model service" if is_service else "pipeline"
-    aigear_config = AigearConfig.get_config()
-    image_path = get_image_path(is_service=is_service)
-    local = LocalImage(image_path)
-    registry = RegistryImage(image_path)
-
-    deleted_local = local.prune(keep=keep)
-    logger.info(f"Pruned {len(deleted_local)} local {log_tag} tags: {deleted_local}")
-
-    if is_push:
-        registry.configure_auth(aigear_config.gcp.location)
-        deleted_registry = registry.prune(keep=keep)
-        logger.info(
-            f"Pruned {len(deleted_registry)} registry {log_tag} tags: {deleted_registry}"
-        )
-    return True

--- a/src/aigear/deploy/gcp/artifacts_image.py
+++ b/src/aigear/deploy/gcp/artifacts_image.py
@@ -188,6 +188,7 @@ def create_artifacts_image(
     aigear_config = AigearConfig.get_config()
     image_path = get_image_path(is_service=is_service)
     local = LocalImage(image_path)
+    registry = RegistryImage(image_path)
 
     if is_build:
         if dockerfile_path:
@@ -197,9 +198,68 @@ def create_artifacts_image(
         logger.info(f"The {log_tag} image has been created.")
 
     if is_push:
-        location = aigear_config.gcp.location
-        run_sh(["gcloud", "auth", "configure-docker", f"{location}-docker.pkg.dev", "--quiet"])
-        if run_sh_stream(["docker", "push", image_path]) != 0:
+        registry.configure_auth(aigear_config.gcp.location)
+        if not registry.push():
             return False
         logger.info(f"The {log_tag} image has been pushed.")
+    return True
+
+
+def delete_artifacts_image(is_service=False, is_push=False) -> bool:
+    """Returns True if the requested operations succeeded, False otherwise."""
+    log_tag = "model service" if is_service else "pipeline"
+    aigear_config = AigearConfig.get_config()
+    image_path = get_image_path(is_service=is_service)
+    local = LocalImage(image_path)
+    registry = RegistryImage(image_path)
+
+    if not local.remove():
+        return False
+    logger.info(f"The {log_tag} local image has been deleted.")
+
+    if is_push:
+        registry.configure_auth(aigear_config.gcp.location)
+        if not registry.delete():
+            return False
+        logger.info(f"The {log_tag} registry image has been deleted.")
+    return True
+
+
+def retag_artifacts_image(
+    src_tag: str, target_tag: str, is_service=False, is_push=False
+) -> bool:
+    """Returns True if the requested operations succeeded, False otherwise."""
+    log_tag = "model service" if is_service else "pipeline"
+    aigear_config = AigearConfig.get_config()
+    image_path = get_image_path(is_service=is_service)
+    local = LocalImage(image_path)
+    registry = RegistryImage(image_path)
+
+    if not local.tag(src_tag=src_tag, target_tag=target_tag):
+        return False
+    logger.info(f"The {log_tag} local image has been retagged {src_tag} -> {target_tag}.")
+
+    if is_push:
+        registry.configure_auth(aigear_config.gcp.location)
+        if not registry.retag(src_tag=src_tag, target_tag=target_tag):
+            return False
+        logger.info(f"The {log_tag} registry image has been retagged {src_tag} -> {target_tag}.")
+    return True
+
+
+def prune_artifacts_image(keep: int, is_service=False, is_push=False) -> bool:
+    """Returns True always (prune continues on individual failures)."""
+    log_tag = "model service" if is_service else "pipeline"
+    aigear_config = AigearConfig.get_config()
+    image_path = get_image_path(is_service=is_service)
+    local = LocalImage(image_path)
+    registry = RegistryImage(image_path)
+
+    deleted_local = local.prune(keep=keep)
+    logger.info(f"Pruned {len(deleted_local)} local {log_tag} tags: {deleted_local}")
+
+    if is_push:
+        registry.configure_auth(aigear_config.gcp.location)
+        deleted_registry = registry.prune(keep=keep)
+        logger.info(f"Pruned {len(deleted_registry)} registry {log_tag} tags: {deleted_registry}")
     return True

--- a/src/aigear/deploy/gcp/artifacts_image.py
+++ b/src/aigear/deploy/gcp/artifacts_image.py
@@ -10,61 +10,30 @@ from aigear.common.logger import Logging
 logger = Logging(log_name=__name__).console_logging()
 
 
-class ArtifactsImage:
-    def __init__(self, artifacts_image):
-        self.artifacts_image = artifacts_image
+class LocalImage:
+    def __init__(self, image_path: str):
+        self.image_path = image_path
+        self._image_name = image_path.rsplit(":", 1)[0]
 
-    def create_image(self, dockerfile_path=None, build_context=".") -> bool:
-        """Returns True if the build succeeded, False otherwise."""
+    def build(self, dockerfile_path=None, build_context=".") -> bool:
         if dockerfile_path is None:
             logger.info(
-                "Please specify Dockerfile(Dockerfile.pl or Dockerfile.ms) to build the image."
+                "Please specify Dockerfile (Dockerfile.pl or Dockerfile.ms) to build the image."
             )
             return False
-        command = [
-            "docker",
-            "build",
-            "-f",
-            dockerfile_path,
-            "-t",
-            self.artifacts_image,
-            build_context,
-        ]
-        returncode = run_sh_stream(command)
-        return returncode == 0
+        command = ["docker", "build", "-f", dockerfile_path, "-t", self.image_path, build_context]
+        return run_sh_stream(command) == 0
 
-    @staticmethod
-    def obtain_permissions(location):
+    def tag(self, src_tag: str, target_tag: str) -> bool:
         command = [
-            "gcloud",
-            "auth",
-            "configure-docker",
-            f"{location}-docker.pkg.dev",
-            "--quiet",
+            "docker", "tag",
+            f"{self._image_name}:{src_tag}",
+            f"{self._image_name}:{target_tag}",
         ]
-        event = run_sh(command)
-        logger.info(event)
+        return run_sh_stream(command) == 0
 
-    def push_image(self):
-        command = ["docker", "push", self.artifacts_image]
-        event = run_sh_stream(command)
-        logger.info(event)
-
-    def image_exist_in_artifacts(self):
-        is_exist = True
-        command = [
-            "gcloud",
-            "artifacts",
-            "docker",
-            "images",
-            "describe",
-            self.artifacts_image,
-        ]
-        event = run_sh(command)
-        if ("Image not found" in event or "NOT_FOUND" in event) and "ERROR" in event:
-            is_exist = False
-        logger.info(event)
-        return is_exist
+    def remove(self) -> bool:
+        return run_sh_stream(["docker", "rmi", self.image_path]) == 0
 
 
 def _validate_dockerfile_venvs(dockerfile_path: str, is_service: bool) -> None:
@@ -135,23 +104,20 @@ def create_artifacts_image(
 ) -> bool:
     """Returns True if the requested operations succeeded, False otherwise."""
     log_tag = "model service" if is_service else "pipeline"
-
     aigear_config = AigearConfig.get_config()
-    artifacts_image = get_image_path(is_service=is_service)
-    artifacts_image_instance = ArtifactsImage(artifacts_image=artifacts_image)
+    image_path = get_image_path(is_service=is_service)
+    local = LocalImage(image_path)
 
     if is_build:
         if dockerfile_path:
             _validate_dockerfile_venvs(dockerfile_path, is_service)
-        success = artifacts_image_instance.create_image(
-            dockerfile_path=dockerfile_path, build_context=build_context
-        )
-        if not success:
+        if not local.build(dockerfile_path=dockerfile_path, build_context=build_context):
             return False
         logger.info(f"The {log_tag} image has been created.")
 
     if is_push:
-        artifacts_image_instance.obtain_permissions(aigear_config.gcp.location)
-        artifacts_image_instance.push_image()
+        location = aigear_config.gcp.location
+        run_sh(["gcloud", "auth", "configure-docker", f"{location}-docker.pkg.dev", "--quiet"])
+        run_sh_stream(["docker", "push", image_path])
         logger.info(f"The {log_tag} image has been pushed.")
     return True

--- a/src/aigear/deploy/gcp/artifacts_image.py
+++ b/src/aigear/deploy/gcp/artifacts_image.py
@@ -21,12 +21,21 @@ class LocalImage:
                 "Please specify Dockerfile (Dockerfile.pl or Dockerfile.ms) to build the image."
             )
             return False
-        command = ["docker", "build", "-f", dockerfile_path, "-t", self.image_path, build_context]
+        command = [
+            "docker",
+            "build",
+            "-f",
+            dockerfile_path,
+            "-t",
+            self.image_path,
+            build_context,
+        ]
         return run_sh_stream(command) == 0
 
     def tag(self, src_tag: str, target_tag: str) -> bool:
         command = [
-            "docker", "tag",
+            "docker",
+            "tag",
             f"{self._image_name}:{src_tag}",
             f"{self._image_name}:{target_tag}",
         ]
@@ -36,13 +45,19 @@ class LocalImage:
         return run_sh_stream(["docker", "rmi", self.image_path]) == 0
 
     def prune(self, keep: int) -> list[str]:
-        output = run_sh([
-            "docker", "images", "--format", "{{.Tag}}\t{{.CreatedAt}}", self._image_name
-        ])
+        output = run_sh(
+            [
+                "docker",
+                "images",
+                "--format",
+                "{{.Tag}}\t{{.CreatedAt}}",
+                self._image_name,
+            ]
+        )
         entries = []
         for line in output.strip().splitlines():
             parts = line.strip().split("\t", 1)
-            if len(parts) == 2:
+            if len(parts) == 2 and parts[0] != "latest":
                 entries.append((parts[0], parts[1]))
         entries.sort(key=lambda x: x[1], reverse=True)  # newest first
         to_delete = entries[keep:]
@@ -61,55 +76,93 @@ class RegistryImage:
         self._image_name = image_path.rsplit(":", 1)[0]
 
     def configure_auth(self, location: str) -> None:
-        event = run_sh([
-            "gcloud", "auth", "configure-docker",
-            f"{location}-docker.pkg.dev", "--quiet",
-        ])
+        event = run_sh(
+            [
+                "gcloud",
+                "auth",
+                "configure-docker",
+                f"{location}-docker.pkg.dev",
+                "--quiet",
+            ]
+        )
         logger.info(event)
 
     def push(self) -> bool:
         return run_sh_stream(["docker", "push", self.image_path]) == 0
 
     def exists(self) -> bool:
-        event = run_sh([
-            "gcloud", "artifacts", "docker", "images", "describe", self.image_path
-        ])
+        event = run_sh(
+            ["gcloud", "artifacts", "docker", "images", "describe", self.image_path]
+        )
         logger.info(event)
-        return not (("Image not found" in event or "NOT_FOUND" in event) and "ERROR" in event)
+        return not (
+            ("Image not found" in event or "NOT_FOUND" in event) and "ERROR" in event
+        )
 
     def delete(self) -> bool:
-        result = run_sh([
-            "gcloud", "artifacts", "docker", "images", "delete",
-            self.image_path, "--delete-tags", "--quiet",
-        ])
+        result = run_sh(
+            [
+                "gcloud",
+                "artifacts",
+                "docker",
+                "images",
+                "delete",
+                self.image_path,
+                "--delete-tags",
+                "--quiet",
+            ]
+        )
         logger.info(result)
         return "ERROR" not in result
 
     def retag(self, src_tag: str, target_tag: str) -> bool:
-        result = run_sh([
-            "gcloud", "artifacts", "docker", "tags", "add",
-            f"{self._image_name}:{src_tag}",
-            f"{self._image_name}:{target_tag}",
-        ])
+        result = run_sh(
+            [
+                "gcloud",
+                "artifacts",
+                "docker",
+                "tags",
+                "add",
+                f"{self._image_name}:{src_tag}",
+                f"{self._image_name}:{target_tag}",
+            ]
+        )
         logger.info(result)
         return "ERROR" not in result
 
     def prune(self, keep: int) -> list[str]:
-        output = run_sh([
-            "gcloud", "artifacts", "docker", "images", "list",
-            self._image_name,
-            "--include-tags",
-            "--sort-by=~createTime",
-            "--format=value(tags)",
-        ])
-        tags = [line.strip() for line in output.strip().splitlines() if line.strip()]
+        output = run_sh(
+            [
+                "gcloud",
+                "artifacts",
+                "docker",
+                "images",
+                "list",
+                self._image_name,
+                "--include-tags",
+                "--sort-by=~createTime",
+                "--format=value(tags)",
+            ]
+        )
+        tags = [
+            line.strip()
+            for line in output.strip().splitlines()
+            if line.strip() and line.strip() != "latest"
+        ]
         to_delete = tags[keep:]
         deleted = []
         for tag in to_delete:
-            result = run_sh([
-                "gcloud", "artifacts", "docker", "images", "delete",
-                f"{self._image_name}:{tag}", "--quiet",
-            ])
+            result = run_sh(
+                [
+                    "gcloud",
+                    "artifacts",
+                    "docker",
+                    "images",
+                    "delete",
+                    f"{self._image_name}:{tag}",
+                    "--quiet",
+                ]
+            )
             if "ERROR" not in result:
                 deleted.append(tag)
             else:
@@ -193,7 +246,9 @@ def create_artifacts_image(
     if is_build:
         if dockerfile_path:
             _validate_dockerfile_venvs(dockerfile_path, is_service)
-        if not local.build(dockerfile_path=dockerfile_path, build_context=build_context):
+        if not local.build(
+            dockerfile_path=dockerfile_path, build_context=build_context
+        ):
             return False
         logger.info(f"The {log_tag} image has been created.")
 
@@ -237,13 +292,17 @@ def retag_artifacts_image(
 
     if not local.tag(src_tag=src_tag, target_tag=target_tag):
         return False
-    logger.info(f"The {log_tag} local image has been retagged {src_tag} -> {target_tag}.")
+    logger.info(
+        f"The {log_tag} local image has been retagged {src_tag} -> {target_tag}."
+    )
 
     if is_push:
         registry.configure_auth(aigear_config.gcp.location)
         if not registry.retag(src_tag=src_tag, target_tag=target_tag):
             return False
-        logger.info(f"The {log_tag} registry image has been retagged {src_tag} -> {target_tag}.")
+        logger.info(
+            f"The {log_tag} registry image has been retagged {src_tag} -> {target_tag}."
+        )
     return True
 
 
@@ -261,5 +320,7 @@ def prune_artifacts_image(keep: int, is_service=False, is_push=False) -> bool:
     if is_push:
         registry.configure_auth(aigear_config.gcp.location)
         deleted_registry = registry.prune(keep=keep)
-        logger.info(f"Pruned {len(deleted_registry)} registry {log_tag} tags: {deleted_registry}")
+        logger.info(
+            f"Pruned {len(deleted_registry)} registry {log_tag} tags: {deleted_registry}"
+        )
     return True

--- a/src/aigear/deploy/gcp/artifacts_image.py
+++ b/src/aigear/deploy/gcp/artifacts_image.py
@@ -114,7 +114,6 @@ class RegistryImage:
                 deleted.append(tag)
             else:
                 logger.warning(f"Failed to delete registry tag {tag}: {result}")
-                break
         return deleted
 
 

--- a/src/aigear/deploy/gcp/artifacts_image.py
+++ b/src/aigear/deploy/gcp/artifacts_image.py
@@ -118,6 +118,7 @@ def create_artifacts_image(
     if is_push:
         location = aigear_config.gcp.location
         run_sh(["gcloud", "auth", "configure-docker", f"{location}-docker.pkg.dev", "--quiet"])
-        run_sh_stream(["docker", "push", image_path])
+        if run_sh_stream(["docker", "push", image_path]) != 0:
+            return False
         logger.info(f"The {log_tag} image has been pushed.")
     return True

--- a/src/aigear/deploy/gcp/artifacts_image.py
+++ b/src/aigear/deploy/gcp/artifacts_image.py
@@ -85,6 +85,38 @@ class RegistryImage:
         logger.info(result)
         return "ERROR" not in result
 
+    def retag(self, src_tag: str, target_tag: str) -> bool:
+        result = run_sh([
+            "gcloud", "artifacts", "docker", "tags", "add",
+            f"{self._image_name}:{src_tag}",
+            f"{self._image_name}:{target_tag}",
+        ])
+        logger.info(result)
+        return "ERROR" not in result
+
+    def prune(self, keep: int) -> list[str]:
+        output = run_sh([
+            "gcloud", "artifacts", "docker", "images", "list",
+            self._image_name,
+            "--include-tags",
+            "--sort-by=~createTime",
+            "--format=value(tags)",
+        ])
+        tags = [line.strip() for line in output.strip().splitlines() if line.strip()]
+        to_delete = tags[keep:]
+        deleted = []
+        for tag in to_delete:
+            result = run_sh([
+                "gcloud", "artifacts", "docker", "images", "delete",
+                f"{self._image_name}:{tag}", "--quiet",
+            ])
+            if "ERROR" not in result:
+                deleted.append(tag)
+            else:
+                logger.warning(f"Failed to delete registry tag {tag}: {result}")
+                break
+        return deleted
+
 
 def _validate_dockerfile_venvs(dockerfile_path: str, is_service: bool) -> None:
     """

--- a/src/aigear/deploy/gcp/artifacts_image.py
+++ b/src/aigear/deploy/gcp/artifacts_image.py
@@ -35,6 +35,25 @@ class LocalImage:
     def remove(self) -> bool:
         return run_sh_stream(["docker", "rmi", self.image_path]) == 0
 
+    def prune(self, keep: int) -> list[str]:
+        output = run_sh([
+            "docker", "images", "--format", "{{.Tag}}\t{{.CreatedAt}}", self._image_name
+        ])
+        entries = []
+        for line in output.strip().splitlines():
+            parts = line.strip().split("\t", 1)
+            if len(parts) == 2:
+                entries.append((parts[0], parts[1]))
+        entries.sort(key=lambda x: x[1], reverse=True)  # newest first
+        to_delete = entries[keep:]
+        deleted = []
+        for tag, _ in to_delete:
+            if run_sh_stream(["docker", "rmi", f"{self._image_name}:{tag}"]) == 0:
+                deleted.append(tag)
+            else:
+                logger.warning(f"Failed to remove local image tag: {tag}")
+        return deleted
+
 
 def _validate_dockerfile_venvs(dockerfile_path: str, is_service: bool) -> None:
     """

--- a/src/aigear/deploy/gcp/artifacts_image.py
+++ b/src/aigear/deploy/gcp/artifacts_image.py
@@ -55,6 +55,37 @@ class LocalImage:
         return deleted
 
 
+class RegistryImage:
+    def __init__(self, image_path: str):
+        self.image_path = image_path
+        self._image_name = image_path.rsplit(":", 1)[0]
+
+    def configure_auth(self, location: str) -> None:
+        event = run_sh([
+            "gcloud", "auth", "configure-docker",
+            f"{location}-docker.pkg.dev", "--quiet",
+        ])
+        logger.info(event)
+
+    def push(self) -> bool:
+        return run_sh_stream(["docker", "push", self.image_path]) == 0
+
+    def exists(self) -> bool:
+        event = run_sh([
+            "gcloud", "artifacts", "docker", "images", "describe", self.image_path
+        ])
+        logger.info(event)
+        return not (("Image not found" in event or "NOT_FOUND" in event) and "ERROR" in event)
+
+    def delete(self) -> bool:
+        result = run_sh([
+            "gcloud", "artifacts", "docker", "images", "delete",
+            self.image_path, "--delete-tags", "--quiet",
+        ])
+        logger.info(result)
+        return "ERROR" not in result
+
+
 def _validate_dockerfile_venvs(dockerfile_path: str, is_service: bool) -> None:
     """
     Two-stage validation before building a Docker image.

--- a/tests/cli/test_artifacts_image_cli.py
+++ b/tests/cli/test_artifacts_image_cli.py
@@ -1,5 +1,5 @@
 import importlib
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/cli/test_artifacts_image_cli.py
+++ b/tests/cli/test_artifacts_image_cli.py
@@ -3,14 +3,17 @@ from unittest.mock import patch
 
 import pytest
 
-
 # ── --create ──────────────────────────────────────────────────────────────────
+
 
 def test_create_dispatches_to_create_artifacts_image():
     with patch("sys.argv", ["cmd", "--create", "--dockerfile_path", "Dockerfile.pl"]):
         import aigear.cli.artifacts_image as cli_mod
+
         importlib.reload(cli_mod)
-        with patch("aigear.cli.artifacts_image.create_artifacts_image", return_value=True) as mock_fn:
+        with patch(
+            "aigear.cli.artifacts_image.create_artifacts_image", return_value=True
+        ) as mock_fn:
             cli_mod.docker_image()
     mock_fn.assert_called_once_with(
         dockerfile_path="Dockerfile.pl",
@@ -22,42 +25,88 @@ def test_create_dispatches_to_create_artifacts_image():
 
 
 def test_create_push_sets_is_push_true():
-    with patch("sys.argv", ["cmd", "--create", "--dockerfile_path", "Dockerfile.pl", "--push"]):
+    with patch(
+        "sys.argv", ["cmd", "--create", "--dockerfile_path", "Dockerfile.pl", "--push"]
+    ):
         import aigear.cli.artifacts_image as cli_mod
+
         importlib.reload(cli_mod)
-        with patch("aigear.cli.artifacts_image.create_artifacts_image", return_value=True) as mock_fn:
+        with patch(
+            "aigear.cli.artifacts_image.create_artifacts_image", return_value=True
+        ) as mock_fn:
             cli_mod.docker_image()
     assert mock_fn.call_args.kwargs["is_push"] is True
 
 
+def test_create_no_dockerfile_defaults_to_pipeline():
+    with patch("sys.argv", ["cmd", "--create"]):
+        import aigear.cli.artifacts_image as cli_mod
+
+        importlib.reload(cli_mod)
+        with patch(
+            "aigear.cli.artifacts_image.create_artifacts_image", return_value=True
+        ) as mock_fn:
+            cli_mod.docker_image()
+    mock_fn.assert_called_once_with(
+        dockerfile_path=None,
+        build_context=".",
+        is_service=False,
+        is_build=True,
+        is_push=False,
+    )
+
+
 # ── --delete ──────────────────────────────────────────────────────────────────
+
 
 def test_delete_dispatches_to_delete_artifacts_image():
     with patch("sys.argv", ["cmd", "--delete"]):
         import aigear.cli.artifacts_image as cli_mod
+
         importlib.reload(cli_mod)
-        with patch("aigear.cli.artifacts_image.delete_artifacts_image", return_value=True) as mock_fn:
+        with patch(
+            "aigear.cli.artifacts_image.delete_artifacts_image", return_value=True
+        ) as mock_fn:
             cli_mod.docker_image()
     mock_fn.assert_called_once_with(is_service=False, is_push=False)
+
+
+def test_delete_is_service_targets_service():
+    with patch("sys.argv", ["cmd", "--delete", "--is_service"]):
+        import aigear.cli.artifacts_image as cli_mod
+
+        importlib.reload(cli_mod)
+        with patch(
+            "aigear.cli.artifacts_image.delete_artifacts_image", return_value=True
+        ) as mock_fn:
+            cli_mod.docker_image()
+    mock_fn.assert_called_once_with(is_service=True, is_push=False)
 
 
 def test_delete_push_sets_is_push_true():
     with patch("sys.argv", ["cmd", "--delete", "--push"]):
         import aigear.cli.artifacts_image as cli_mod
+
         importlib.reload(cli_mod)
-        with patch("aigear.cli.artifacts_image.delete_artifacts_image", return_value=True) as mock_fn:
+        with patch(
+            "aigear.cli.artifacts_image.delete_artifacts_image", return_value=True
+        ) as mock_fn:
             cli_mod.docker_image()
     assert mock_fn.call_args.kwargs["is_push"] is True
 
 
 # ── --retag ───────────────────────────────────────────────────────────────────
 
+
 def test_retag_dispatches_with_src_and_target():
     argv = ["cmd", "--retag", "--src_tag", "v1.0", "--target_tag", "latest"]
     with patch("sys.argv", argv):
         import aigear.cli.artifacts_image as cli_mod
+
         importlib.reload(cli_mod)
-        with patch("aigear.cli.artifacts_image.retag_artifacts_image", return_value=True) as mock_fn:
+        with patch(
+            "aigear.cli.artifacts_image.retag_artifacts_image", return_value=True
+        ) as mock_fn:
             cli_mod.docker_image()
     mock_fn.assert_called_once_with(
         src_tag="v1.0", target_tag="latest", is_service=False, is_push=False
@@ -67,6 +116,7 @@ def test_retag_dispatches_with_src_and_target():
 def test_retag_without_src_tag_exits():
     with patch("sys.argv", ["cmd", "--retag", "--target_tag", "latest"]):
         import aigear.cli.artifacts_image as cli_mod
+
         importlib.reload(cli_mod)
         with pytest.raises(SystemExit):
             cli_mod.docker_image()
@@ -75,16 +125,83 @@ def test_retag_without_src_tag_exits():
 def test_retag_without_target_tag_exits():
     with patch("sys.argv", ["cmd", "--retag", "--src_tag", "v1.0"]):
         import aigear.cli.artifacts_image as cli_mod
+
         importlib.reload(cli_mod)
         with pytest.raises(SystemExit):
             cli_mod.docker_image()
 
 
+# ── --all ─────────────────────────────────────────────────────────────────────
+
+
+def test_all_create_dispatches_both_images():
+    from aigear.common.constant import DOCKERFILE_PIPELINE, DOCKERFILE_SERVICE
+
+    with patch("sys.argv", ["cmd", "--create", "--all"]):
+        import aigear.cli.artifacts_image as cli_mod
+
+        importlib.reload(cli_mod)
+        with patch(
+            "aigear.cli.artifacts_image.create_artifacts_image", return_value=True
+        ) as mock_fn:
+            cli_mod.docker_image()
+    assert mock_fn.call_count == 2
+    mock_fn.assert_any_call(
+        dockerfile_path=DOCKERFILE_PIPELINE,
+        build_context=".",
+        is_service=False,
+        is_build=True,
+        is_push=False,
+    )
+    mock_fn.assert_any_call(
+        dockerfile_path=DOCKERFILE_SERVICE,
+        build_context=".",
+        is_service=True,
+        is_build=True,
+        is_push=False,
+    )
+
+
+def test_all_delete_dispatches_both_images():
+    with patch("sys.argv", ["cmd", "--delete", "--all"]):
+        import aigear.cli.artifacts_image as cli_mod
+
+        importlib.reload(cli_mod)
+        with patch(
+            "aigear.cli.artifacts_image.delete_artifacts_image", return_value=True
+        ) as mock_fn:
+            cli_mod.docker_image()
+    assert mock_fn.call_count == 2
+    mock_fn.assert_any_call(is_service=False, is_push=False)
+    mock_fn.assert_any_call(is_service=True, is_push=False)
+
+
+def test_all_retag_dispatches_both_images():
+    argv = ["cmd", "--retag", "--src_tag", "v1.0", "--target_tag", "latest", "--all"]
+    with patch("sys.argv", argv):
+        import aigear.cli.artifacts_image as cli_mod
+
+        importlib.reload(cli_mod)
+        with patch(
+            "aigear.cli.artifacts_image.retag_artifacts_image", return_value=True
+        ) as mock_fn:
+            cli_mod.docker_image()
+    assert mock_fn.call_count == 2
+    mock_fn.assert_any_call(
+        src_tag="v1.0", target_tag="latest", is_service=False, is_push=False
+    )
+    mock_fn.assert_any_call(
+        src_tag="v1.0", target_tag="latest", is_service=True, is_push=False
+    )
+
+
 # ── no action ─────────────────────────────────────────────────────────────────
+
 
 def test_no_action_exits():
     with patch("sys.argv", ["cmd"]):
         import aigear.cli.artifacts_image as cli_mod
+
         importlib.reload(cli_mod)
         with pytest.raises(SystemExit):
             cli_mod.docker_image()

--- a/tests/cli/test_artifacts_image_cli.py
+++ b/tests/cli/test_artifacts_image_cli.py
@@ -1,0 +1,117 @@
+import importlib
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+# ── --create ──────────────────────────────────────────────────────────────────
+
+def test_create_dispatches_to_create_artifacts_image():
+    with patch("sys.argv", ["cmd", "--create", "--dockerfile_path", "Dockerfile.pl"]):
+        import aigear.cli.artifacts_image as cli_mod
+        importlib.reload(cli_mod)
+        with patch("aigear.cli.artifacts_image.create_artifacts_image", return_value=True) as mock_fn:
+            cli_mod.docker_image()
+    mock_fn.assert_called_once_with(
+        dockerfile_path="Dockerfile.pl",
+        build_context=".",
+        is_service=False,
+        is_build=True,
+        is_push=False,
+    )
+
+
+def test_create_push_sets_is_push_true():
+    with patch("sys.argv", ["cmd", "--create", "--dockerfile_path", "Dockerfile.pl", "--push"]):
+        import aigear.cli.artifacts_image as cli_mod
+        importlib.reload(cli_mod)
+        with patch("aigear.cli.artifacts_image.create_artifacts_image", return_value=True) as mock_fn:
+            cli_mod.docker_image()
+    assert mock_fn.call_args.kwargs["is_push"] is True
+
+
+# ── --delete ──────────────────────────────────────────────────────────────────
+
+def test_delete_dispatches_to_delete_artifacts_image():
+    with patch("sys.argv", ["cmd", "--delete"]):
+        import aigear.cli.artifacts_image as cli_mod
+        importlib.reload(cli_mod)
+        with patch("aigear.cli.artifacts_image.delete_artifacts_image", return_value=True) as mock_fn:
+            cli_mod.docker_image()
+    mock_fn.assert_called_once_with(is_service=False, is_push=False)
+
+
+def test_delete_push_sets_is_push_true():
+    with patch("sys.argv", ["cmd", "--delete", "--push"]):
+        import aigear.cli.artifacts_image as cli_mod
+        importlib.reload(cli_mod)
+        with patch("aigear.cli.artifacts_image.delete_artifacts_image", return_value=True) as mock_fn:
+            cli_mod.docker_image()
+    assert mock_fn.call_args.kwargs["is_push"] is True
+
+
+# ── --retag ───────────────────────────────────────────────────────────────────
+
+def test_retag_dispatches_with_src_and_target():
+    argv = ["cmd", "--retag", "--src_tag", "v1.0", "--target_tag", "latest"]
+    with patch("sys.argv", argv):
+        import aigear.cli.artifacts_image as cli_mod
+        importlib.reload(cli_mod)
+        with patch("aigear.cli.artifacts_image.retag_artifacts_image", return_value=True) as mock_fn:
+            cli_mod.docker_image()
+    mock_fn.assert_called_once_with(
+        src_tag="v1.0", target_tag="latest", is_service=False, is_push=False
+    )
+
+
+def test_retag_without_src_tag_exits():
+    with patch("sys.argv", ["cmd", "--retag", "--target_tag", "latest"]):
+        import aigear.cli.artifacts_image as cli_mod
+        importlib.reload(cli_mod)
+        with pytest.raises(SystemExit):
+            cli_mod.docker_image()
+
+
+def test_retag_without_target_tag_exits():
+    with patch("sys.argv", ["cmd", "--retag", "--src_tag", "v1.0"]):
+        import aigear.cli.artifacts_image as cli_mod
+        importlib.reload(cli_mod)
+        with pytest.raises(SystemExit):
+            cli_mod.docker_image()
+
+
+# ── --prune ───────────────────────────────────────────────────────────────────
+
+def test_prune_dispatches_with_keep():
+    with patch("sys.argv", ["cmd", "--prune", "--keep", "5"]):
+        import aigear.cli.artifacts_image as cli_mod
+        importlib.reload(cli_mod)
+        with patch("aigear.cli.artifacts_image.prune_artifacts_image", return_value=True) as mock_fn:
+            cli_mod.docker_image()
+    mock_fn.assert_called_once_with(keep=5, is_service=False, is_push=False)
+
+
+def test_prune_without_keep_exits():
+    with patch("sys.argv", ["cmd", "--prune"]):
+        import aigear.cli.artifacts_image as cli_mod
+        importlib.reload(cli_mod)
+        with pytest.raises(SystemExit):
+            cli_mod.docker_image()
+
+
+def test_prune_keep_zero_exits():
+    with patch("sys.argv", ["cmd", "--prune", "--keep", "0"]):
+        import aigear.cli.artifacts_image as cli_mod
+        importlib.reload(cli_mod)
+        with pytest.raises(SystemExit):
+            cli_mod.docker_image()
+
+
+# ── no action ─────────────────────────────────────────────────────────────────
+
+def test_no_action_exits():
+    with patch("sys.argv", ["cmd"]):
+        import aigear.cli.artifacts_image as cli_mod
+        importlib.reload(cli_mod)
+        with pytest.raises(SystemExit):
+            cli_mod.docker_image()

--- a/tests/cli/test_artifacts_image_cli.py
+++ b/tests/cli/test_artifacts_image_cli.py
@@ -80,33 +80,6 @@ def test_retag_without_target_tag_exits():
             cli_mod.docker_image()
 
 
-# ── --prune ───────────────────────────────────────────────────────────────────
-
-def test_prune_dispatches_with_keep():
-    with patch("sys.argv", ["cmd", "--prune", "--keep", "5"]):
-        import aigear.cli.artifacts_image as cli_mod
-        importlib.reload(cli_mod)
-        with patch("aigear.cli.artifacts_image.prune_artifacts_image", return_value=True) as mock_fn:
-            cli_mod.docker_image()
-    mock_fn.assert_called_once_with(keep=5, is_service=False, is_push=False)
-
-
-def test_prune_without_keep_exits():
-    with patch("sys.argv", ["cmd", "--prune"]):
-        import aigear.cli.artifacts_image as cli_mod
-        importlib.reload(cli_mod)
-        with pytest.raises(SystemExit):
-            cli_mod.docker_image()
-
-
-def test_prune_keep_zero_exits():
-    with patch("sys.argv", ["cmd", "--prune", "--keep", "0"]):
-        import aigear.cli.artifacts_image as cli_mod
-        importlib.reload(cli_mod)
-        with pytest.raises(SystemExit):
-            cli_mod.docker_image()
-
-
 # ── no action ─────────────────────────────────────────────────────────────────
 
 def test_no_action_exits():

--- a/tests/cli/test_artifacts_image_cli.py
+++ b/tests/cli/test_artifacts_image_cli.py
@@ -56,6 +56,24 @@ def test_create_no_dockerfile_defaults_to_pipeline():
     )
 
 
+def test_create_dockerfile_ms_infers_is_service():
+    with patch("sys.argv", ["cmd", "--create", "--dockerfile_path", "Dockerfile.ms"]):
+        import aigear.cli.artifacts_image as cli_mod
+
+        importlib.reload(cli_mod)
+        with patch(
+            "aigear.cli.artifacts_image.create_artifacts_image", return_value=True
+        ) as mock_fn:
+            cli_mod.docker_image()
+    mock_fn.assert_called_once_with(
+        dockerfile_path="Dockerfile.ms",
+        build_context=".",
+        is_service=True,
+        is_build=True,
+        is_push=False,
+    )
+
+
 # ── --delete ──────────────────────────────────────────────────────────────────
 
 

--- a/tests/cli/test_env_schema_cli.py
+++ b/tests/cli/test_env_schema_cli.py
@@ -1,0 +1,91 @@
+import importlib
+from unittest.mock import patch
+
+import pytest
+
+
+# ── --generate ────────────────────────────────────────────────────────────────
+
+
+def test_generate_calls_generative_env_schema():
+    with patch("sys.argv", ["aigear-env-schema", "--generate"]):
+        import aigear.cli.env_schema as cli_mod
+
+        importlib.reload(cli_mod)
+        with patch("aigear.cli.env_schema.EnvConfig.generative_env_schema") as mock_fn:
+            cli_mod.env_schema()
+    mock_fn.assert_called_once_with(forced_generate=False)
+
+
+def test_generate_force_passes_forced_generate_true():
+    with patch("sys.argv", ["aigear-env-schema", "--generate", "--force"]):
+        import aigear.cli.env_schema as cli_mod
+
+        importlib.reload(cli_mod)
+        with patch("aigear.cli.env_schema.EnvConfig.generative_env_schema") as mock_fn:
+            cli_mod.env_schema()
+    mock_fn.assert_called_once_with(forced_generate=True)
+
+
+# ── --delete ──────────────────────────────────────────────────────────────────
+
+
+def test_delete_calls_delete_env_schema():
+    with patch("sys.argv", ["aigear-env-schema", "--delete"]):
+        import aigear.cli.env_schema as cli_mod
+
+        importlib.reload(cli_mod)
+        with patch("aigear.cli.env_schema.EnvConfig.delete_env_schema") as mock_fn:
+            cli_mod.env_schema()
+    mock_fn.assert_called_once()
+
+
+def test_delete_does_not_call_generate():
+    with patch("sys.argv", ["aigear-env-schema", "--delete"]):
+        import aigear.cli.env_schema as cli_mod
+
+        importlib.reload(cli_mod)
+        with patch("aigear.cli.env_schema.EnvConfig.delete_env_schema"):
+            with patch(
+                "aigear.cli.env_schema.EnvConfig.generative_env_schema"
+            ) as mock_gen:
+                cli_mod.env_schema()
+    mock_gen.assert_not_called()
+
+
+# ── --show ────────────────────────────────────────────────────────────────────
+
+
+def test_show_calls_show_env_schema():
+    with patch("sys.argv", ["aigear-env-schema", "--show"]):
+        import aigear.cli.env_schema as cli_mod
+
+        importlib.reload(cli_mod)
+        with patch("aigear.cli.env_schema.EnvConfig.show_env_schema") as mock_fn:
+            cli_mod.env_schema()
+    mock_fn.assert_called_once()
+
+
+def test_show_does_not_call_generate():
+    with patch("sys.argv", ["aigear-env-schema", "--show"]):
+        import aigear.cli.env_schema as cli_mod
+
+        importlib.reload(cli_mod)
+        with patch("aigear.cli.env_schema.EnvConfig.show_env_schema"):
+            with patch(
+                "aigear.cli.env_schema.EnvConfig.generative_env_schema"
+            ) as mock_gen:
+                cli_mod.env_schema()
+    mock_gen.assert_not_called()
+
+
+# ── no action ─────────────────────────────────────────────────────────────────
+
+
+def test_no_action_exits():
+    with patch("sys.argv", ["aigear-env-schema"]):
+        import aigear.cli.env_schema as cli_mod
+
+        importlib.reload(cli_mod)
+        with pytest.raises(SystemExit):
+            cli_mod.env_schema()

--- a/tests/cli/test_gcp_cli.py
+++ b/tests/cli/test_gcp_cli.py
@@ -3,7 +3,7 @@ from unittest.mock import patch, MagicMock
 
 
 def test_update_flag_calls_infra_update():
-    with patch("sys.argv", ["aigear-gcp-infra", "--update"]):
+    with patch("sys.argv", ["aigear-infra", "--update"]):
         from aigear.cli import gcp_cli
         importlib.reload(gcp_cli)
 
@@ -19,7 +19,7 @@ def test_update_flag_calls_infra_update():
 
 
 def test_create_flag_does_not_call_update():
-    with patch("sys.argv", ["aigear-gcp-infra", "--create"]):
+    with patch("sys.argv", ["aigear-infra", "--create"]):
         from aigear.cli import gcp_cli
         importlib.reload(gcp_cli)
 
@@ -35,7 +35,7 @@ def test_create_flag_does_not_call_update():
 
 
 def test_delete_flag_calls_infra_delete():
-    with patch("sys.argv", ["aigear-gcp-infra", "--delete"]):
+    with patch("sys.argv", ["aigear-infra", "--delete"]):
         from aigear.cli import gcp_cli
         importlib.reload(gcp_cli)
 
@@ -51,7 +51,7 @@ def test_delete_flag_calls_infra_delete():
 
 
 def test_status_flag_calls_infra_status():
-    with patch("sys.argv", ["aigear-gcp-infra", "--status"]):
+    with patch("sys.argv", ["aigear-infra", "--status"]):
         from aigear.cli import gcp_cli
         importlib.reload(gcp_cli)
 

--- a/tests/deploy/gcp/test_artifacts_image.py
+++ b/tests/deploy/gcp/test_artifacts_image.py
@@ -159,3 +159,59 @@ def test_validate_passes_when_no_venv_configured(tmp_path):
     pipelines = {"v1": {"schedule": "0 9 * * *"}}
     with patch("aigear.deploy.gcp.artifacts_image.AppConfig.pipelines", return_value=pipelines):
         _validate_dockerfile_venvs(str(dockerfile), is_service=False)  # must not raise
+
+
+# ── LocalImage.prune ──────────────────────────────────────────────────────────
+
+DOCKER_IMAGES_OUTPUT = (
+    "v3\t2024-03-01 10:00:00 +0000 UTC\n"
+    "v2\t2024-02-01 10:00:00 +0000 UTC\n"
+    "v1\t2024-01-01 10:00:00 +0000 UTC\n"
+)
+
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh_stream")
+@patch("aigear.deploy.gcp.artifacts_image.run_sh")
+def test_local_prune_deletes_oldest_beyond_keep(mock_run_sh, mock_stream):
+    mock_run_sh.return_value = DOCKER_IMAGES_OUTPUT
+    mock_stream.return_value = 0
+    deleted = _make_local().prune(keep=2)
+    assert deleted == ["v1"]
+    mock_stream.assert_called_once_with(["docker", "rmi", f"{IMAGE_NAME}:v1"])
+
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh_stream")
+@patch("aigear.deploy.gcp.artifacts_image.run_sh")
+def test_local_prune_keeps_all_when_keep_exceeds_count(mock_run_sh, mock_stream):
+    mock_run_sh.return_value = DOCKER_IMAGES_OUTPUT
+    deleted = _make_local().prune(keep=10)
+    assert deleted == []
+    mock_stream.assert_not_called()
+
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh_stream")
+@patch("aigear.deploy.gcp.artifacts_image.run_sh")
+def test_local_prune_keep_1_deletes_all_but_newest(mock_run_sh, mock_stream):
+    mock_run_sh.return_value = DOCKER_IMAGES_OUTPUT
+    mock_stream.return_value = 0
+    deleted = _make_local().prune(keep=1)
+    assert deleted == ["v2", "v1"]
+
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh_stream")
+@patch("aigear.deploy.gcp.artifacts_image.run_sh")
+def test_local_prune_skips_failed_deletes(mock_run_sh, mock_stream):
+    mock_run_sh.return_value = DOCKER_IMAGES_OUTPUT
+    mock_stream.return_value = 1  # simulate rmi failure
+    deleted = _make_local().prune(keep=1)
+    assert deleted == []
+
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh")
+def test_local_prune_list_command(mock_run_sh):
+    mock_run_sh.return_value = ""
+    _make_local().prune(keep=1)
+    list_cmd = mock_run_sh.call_args[0][0]
+    assert list_cmd == [
+        "docker", "images", "--format", "{{.Tag}}\t{{.CreatedAt}}", IMAGE_NAME
+    ]

--- a/tests/deploy/gcp/test_artifacts_image.py
+++ b/tests/deploy/gcp/test_artifacts_image.py
@@ -274,6 +274,16 @@ def test_registry_exists_false_on_not_found_variant(mock_run_sh):
     assert _make_registry().exists() is False
 
 
+@patch("aigear.deploy.gcp.artifacts_image.run_sh")
+def test_registry_exists_correct_command(mock_run_sh):
+    mock_run_sh.return_value = "digest: sha256:abc"
+    _make_registry().exists()
+    cmd = mock_run_sh.call_args[0][0]
+    assert cmd == [
+        "gcloud", "artifacts", "docker", "images", "describe", IMAGE_PATH
+    ]
+
+
 # ── RegistryImage.delete ──────────────────────────────────────────────────────
 
 @patch("aigear.deploy.gcp.artifacts_image.run_sh")

--- a/tests/deploy/gcp/test_artifacts_image.py
+++ b/tests/deploy/gcp/test_artifacts_image.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import patch
 
 from aigear.common.constant import VENV_BASE_DIR
-from aigear.deploy.gcp.artifacts_image import LocalImage, _validate_dockerfile_venvs
+from aigear.deploy.gcp.artifacts_image import LocalImage, RegistryImage, _validate_dockerfile_venvs
 
 IMAGE_PATH = "asia-northeast1-docker.pkg.dev/proj/repo/my-image:latest"
 IMAGE_NAME = "asia-northeast1-docker.pkg.dev/proj/repo/my-image"
@@ -214,4 +214,86 @@ def test_local_prune_list_command(mock_run_sh):
     list_cmd = mock_run_sh.call_args[0][0]
     assert list_cmd == [
         "docker", "images", "--format", "{{.Tag}}\t{{.CreatedAt}}", IMAGE_NAME
+    ]
+
+
+def _make_registry() -> RegistryImage:
+    return RegistryImage(image_path=IMAGE_PATH)
+
+
+# ── RegistryImage.configure_auth ─────────────────────────────────────────────
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh")
+def test_registry_configure_auth_command(mock_run_sh):
+    _make_registry().configure_auth("asia-northeast1")
+    cmd = mock_run_sh.call_args[0][0]
+    assert cmd == [
+        "gcloud", "auth", "configure-docker",
+        "asia-northeast1-docker.pkg.dev", "--quiet",
+    ]
+
+
+# ── RegistryImage.push ────────────────────────────────────────────────────────
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh_stream")
+def test_registry_push_returns_true_on_success(mock_stream):
+    mock_stream.return_value = 0
+    assert _make_registry().push() is True
+
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh_stream")
+def test_registry_push_returns_false_on_failure(mock_stream):
+    mock_stream.return_value = 1
+    assert _make_registry().push() is False
+
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh_stream")
+def test_registry_push_correct_command(mock_stream):
+    mock_stream.return_value = 0
+    _make_registry().push()
+    assert mock_stream.call_args[0][0] == ["docker", "push", IMAGE_PATH]
+
+
+# ── RegistryImage.exists ──────────────────────────────────────────────────────
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh")
+def test_registry_exists_true_when_found(mock_run_sh):
+    mock_run_sh.return_value = "digest: sha256:abc"
+    assert _make_registry().exists() is True
+
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh")
+def test_registry_exists_false_when_not_found(mock_run_sh):
+    mock_run_sh.return_value = "ERROR: Image not found"
+    assert _make_registry().exists() is False
+
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh")
+def test_registry_exists_false_on_not_found_variant(mock_run_sh):
+    mock_run_sh.return_value = "ERROR: NOT_FOUND: some resource"
+    assert _make_registry().exists() is False
+
+
+# ── RegistryImage.delete ──────────────────────────────────────────────────────
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh")
+def test_registry_delete_returns_true_on_success(mock_run_sh):
+    mock_run_sh.return_value = "Deleted."
+    assert _make_registry().delete() is True
+
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh")
+def test_registry_delete_returns_false_on_error(mock_run_sh):
+    mock_run_sh.return_value = "ERROR: Image not found"
+    assert _make_registry().delete() is False
+
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh")
+def test_registry_delete_correct_command(mock_run_sh):
+    mock_run_sh.return_value = "Deleted."
+    _make_registry().delete()
+    cmd = mock_run_sh.call_args[0][0]
+    assert cmd == [
+        "gcloud", "artifacts", "docker", "images", "delete",
+        IMAGE_PATH, "--delete-tags", "--quiet",
     ]

--- a/tests/deploy/gcp/test_artifacts_image.py
+++ b/tests/deploy/gcp/test_artifacts_image.py
@@ -225,6 +225,21 @@ def test_local_prune_list_command(mock_run_sh):
     ]
 
 
+@patch("aigear.deploy.gcp.artifacts_image.run_sh_stream")
+@patch("aigear.deploy.gcp.artifacts_image.run_sh")
+def test_local_prune_never_deletes_latest(mock_run_sh, mock_stream):
+    mock_run_sh.return_value = (
+        "latest\t2024-04-01 10:00:00 +0000 UTC\n"
+        "v3\t2024-03-01 10:00:00 +0000 UTC\n"
+        "v2\t2024-02-01 10:00:00 +0000 UTC\n"
+        "v1\t2024-01-01 10:00:00 +0000 UTC\n"
+    )
+    mock_stream.return_value = 0
+    deleted = _make_local().prune(keep=1)
+    assert "latest" not in deleted
+    assert deleted == ["v2", "v1"]
+
+
 def _make_registry() -> RegistryImage:
     return RegistryImage(image_path=IMAGE_PATH)
 
@@ -397,6 +412,18 @@ def test_registry_prune_list_command(mock_run_sh):
         "--sort-by=~createTime",
         "--format=value(tags)",
     ]
+
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh")
+def test_registry_prune_never_deletes_latest(mock_run_sh):
+    mock_run_sh.side_effect = [
+        "latest\nv3\nv2\nv1\n",  # list call — latest appears first
+        "Deleted.",               # delete v2
+        "Deleted.",               # delete v1
+    ]
+    deleted = _make_registry().prune(keep=1)
+    assert "latest" not in deleted
+    assert deleted == ["v2", "v1"]
 
 
 # ── top-level function helpers ────────────────────────────────────────────────

--- a/tests/deploy/gcp/test_artifacts_image.py
+++ b/tests/deploy/gcp/test_artifacts_image.py
@@ -371,10 +371,10 @@ def test_registry_prune_keep_1_deletes_two(mock_run_sh):
 
 @patch("aigear.deploy.gcp.artifacts_image.run_sh")
 def test_registry_prune_skips_failed_deletes(mock_run_sh):
-    mock_run_sh.side_effect = [GCLOUD_TAGS_OUTPUT, "ERROR: not found"]
+    # keep=1, 3 tags (v3,v2,v1) → delete v2 (fails) and v1 (succeeds)
+    mock_run_sh.side_effect = [GCLOUD_TAGS_OUTPUT, "ERROR: not found", "Deleted."]
     deleted = _make_registry().prune(keep=1)
-    assert "v3" not in deleted  # v3 is kept
-    assert deleted == []  # failed delete not included
+    assert deleted == ["v1"]  # v2 failed but v1 still deleted
 
 
 @patch("aigear.deploy.gcp.artifacts_image.run_sh")

--- a/tests/deploy/gcp/test_artifacts_image.py
+++ b/tests/deploy/gcp/test_artifacts_image.py
@@ -1,47 +1,89 @@
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, call
 
 from aigear.common.constant import VENV_BASE_DIR
-from aigear.deploy.gcp.artifacts_image import ArtifactsImage, _validate_dockerfile_venvs
+from aigear.deploy.gcp.artifacts_image import LocalImage, _validate_dockerfile_venvs
+
+IMAGE_PATH = "asia-northeast1-docker.pkg.dev/proj/repo/my-image:latest"
+IMAGE_NAME = "asia-northeast1-docker.pkg.dev/proj/repo/my-image"
 
 
-def _make_artifacts_image(image_name="asia-northeast1-docker.pkg.dev/proj/repo/my-image:latest"):
-    return ArtifactsImage(artifacts_image=image_name)
+def _make_local() -> LocalImage:
+    return LocalImage(image_path=IMAGE_PATH)
 
 
-# ── ArtifactsImage.create_image ──────────────────────────────────────────────
+# ── LocalImage.build ─────────────────────────────────────────────────────────
 
 @patch("aigear.deploy.gcp.artifacts_image.run_sh_stream")
-def test_create_image_returns_true_on_success(mock_stream):
+def test_local_build_returns_true_on_success(mock_stream):
     mock_stream.return_value = 0
-    ai = _make_artifacts_image()
-    assert ai.create_image(dockerfile_path="Dockerfile.pl") is True
+    assert _make_local().build(dockerfile_path="Dockerfile.pl") is True
 
 
 @patch("aigear.deploy.gcp.artifacts_image.run_sh_stream")
-def test_create_image_returns_false_on_failure(mock_stream):
+def test_local_build_returns_false_on_failure(mock_stream):
     mock_stream.return_value = 1
-    ai = _make_artifacts_image()
-    assert ai.create_image(dockerfile_path="Dockerfile.pl") is False
+    assert _make_local().build(dockerfile_path="Dockerfile.pl") is False
 
 
-def test_create_image_returns_false_when_no_dockerfile():
-    ai = _make_artifacts_image()
-    assert ai.create_image(dockerfile_path=None) is False
+def test_local_build_returns_false_when_no_dockerfile():
+    assert _make_local().build(dockerfile_path=None) is False
 
 
 @patch("aigear.deploy.gcp.artifacts_image.run_sh_stream")
-def test_create_image_builds_correct_docker_command(mock_stream):
+def test_local_build_correct_command(mock_stream):
     mock_stream.return_value = 0
-    ai = _make_artifacts_image(image_name="my-image:v1")
-    ai.create_image(dockerfile_path="Dockerfile.pl", build_context=".")
+    _make_local().build(dockerfile_path="Dockerfile.pl", build_context=".")
     cmd = mock_stream.call_args[0][0]
-    assert "docker" in cmd
-    assert "build" in cmd
-    assert "-f" in cmd
-    assert "Dockerfile.pl" in cmd
-    assert "-t" in cmd
-    assert "my-image:v1" in cmd
+    assert cmd == ["docker", "build", "-f", "Dockerfile.pl", "-t", IMAGE_PATH, "."]
+
+
+# ── LocalImage.tag ────────────────────────────────────────────────────────────
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh_stream")
+def test_local_tag_returns_true_on_success(mock_stream):
+    mock_stream.return_value = 0
+    assert _make_local().tag(src_tag="v1.0", target_tag="latest") is True
+
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh_stream")
+def test_local_tag_returns_false_on_failure(mock_stream):
+    mock_stream.return_value = 1
+    assert _make_local().tag(src_tag="v1.0", target_tag="latest") is False
+
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh_stream")
+def test_local_tag_correct_command(mock_stream):
+    mock_stream.return_value = 0
+    _make_local().tag(src_tag="v1.0", target_tag="latest")
+    cmd = mock_stream.call_args[0][0]
+    assert cmd == [
+        "docker", "tag",
+        f"{IMAGE_NAME}:v1.0",
+        f"{IMAGE_NAME}:latest",
+    ]
+
+
+# ── LocalImage.remove ─────────────────────────────────────────────────────────
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh_stream")
+def test_local_remove_returns_true_on_success(mock_stream):
+    mock_stream.return_value = 0
+    assert _make_local().remove() is True
+
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh_stream")
+def test_local_remove_returns_false_on_failure(mock_stream):
+    mock_stream.return_value = 1
+    assert _make_local().remove() is False
+
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh_stream")
+def test_local_remove_correct_command(mock_stream):
+    mock_stream.return_value = 0
+    _make_local().remove()
+    cmd = mock_stream.call_args[0][0]
+    assert cmd == ["docker", "rmi", IMAGE_PATH]
 
 
 # ── ArtifactsImage.image_exist_in_artifacts ──────────────────────────────────

--- a/tests/deploy/gcp/test_artifacts_image.py
+++ b/tests/deploy/gcp/test_artifacts_image.py
@@ -1,8 +1,16 @@
 import pytest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from aigear.common.constant import VENV_BASE_DIR
-from aigear.deploy.gcp.artifacts_image import LocalImage, RegistryImage, _validate_dockerfile_venvs
+from aigear.deploy.gcp.artifacts_image import (
+    LocalImage,
+    RegistryImage,
+    create_artifacts_image,
+    delete_artifacts_image,
+    retag_artifacts_image,
+    prune_artifacts_image,
+    _validate_dockerfile_venvs,
+)
 
 IMAGE_PATH = "asia-northeast1-docker.pkg.dev/proj/repo/my-image:latest"
 IMAGE_NAME = "asia-northeast1-docker.pkg.dev/proj/repo/my-image"
@@ -389,3 +397,136 @@ def test_registry_prune_list_command(mock_run_sh):
         "--sort-by=~createTime",
         "--format=value(tags)",
     ]
+
+
+# ── top-level function helpers ────────────────────────────────────────────────
+
+def _patch_image_path(is_service=False):
+    return patch(
+        "aigear.deploy.gcp.artifacts_image.get_image_path",
+        return_value=IMAGE_PATH,
+    )
+
+
+def _patch_config():
+    cfg = MagicMock()
+    cfg.gcp.location = "asia-northeast1"
+    return patch("aigear.deploy.gcp.artifacts_image.AigearConfig.get_config", return_value=cfg)
+
+
+# ── create_artifacts_image ────────────────────────────────────────────────────
+
+def _patch_validate():
+    return patch("aigear.deploy.gcp.artifacts_image._validate_dockerfile_venvs")
+
+
+def test_create_local_only_does_not_call_registry_push():
+    with _patch_config(), _patch_image_path(), _patch_validate():
+        with patch.object(LocalImage, "build", return_value=True) as mock_build, \
+             patch.object(RegistryImage, "push") as mock_push:
+            result = create_artifacts_image(dockerfile_path="Dockerfile.pl", is_build=True, is_push=False)
+    assert result is True
+    mock_build.assert_called_once()
+    mock_push.assert_not_called()
+
+
+def test_create_fails_fast_when_local_build_fails():
+    with _patch_config(), _patch_image_path(), _patch_validate():
+        with patch.object(LocalImage, "build", return_value=False), \
+             patch.object(RegistryImage, "push") as mock_push:
+            result = create_artifacts_image(dockerfile_path="Dockerfile.pl", is_build=True, is_push=True)
+    assert result is False
+    mock_push.assert_not_called()
+
+
+def test_create_and_push_calls_both():
+    with _patch_config(), _patch_image_path(), _patch_validate():
+        with patch.object(LocalImage, "build", return_value=True), \
+             patch.object(RegistryImage, "configure_auth"), \
+             patch.object(RegistryImage, "push", return_value=True) as mock_push:
+            result = create_artifacts_image(dockerfile_path="Dockerfile.pl", is_build=True, is_push=True)
+    assert result is True
+    mock_push.assert_called_once()
+
+
+# ── delete_artifacts_image ────────────────────────────────────────────────────
+
+def test_delete_local_only_does_not_call_registry_delete():
+    with _patch_config(), _patch_image_path():
+        with patch.object(LocalImage, "remove", return_value=True), \
+             patch.object(RegistryImage, "delete") as mock_del:
+            result = delete_artifacts_image(is_push=False)
+    assert result is True
+    mock_del.assert_not_called()
+
+
+def test_delete_fails_fast_when_local_fails():
+    with _patch_config(), _patch_image_path():
+        with patch.object(LocalImage, "remove", return_value=False), \
+             patch.object(RegistryImage, "delete") as mock_del:
+            result = delete_artifacts_image(is_push=True)
+    assert result is False
+    mock_del.assert_not_called()
+
+
+def test_delete_and_push_calls_both():
+    with _patch_config(), _patch_image_path():
+        with patch.object(LocalImage, "remove", return_value=True), \
+             patch.object(RegistryImage, "configure_auth"), \
+             patch.object(RegistryImage, "delete", return_value=True) as mock_del:
+            result = delete_artifacts_image(is_push=True)
+    assert result is True
+    mock_del.assert_called_once()
+
+
+# ── retag_artifacts_image ─────────────────────────────────────────────────────
+
+def test_retag_local_only():
+    with _patch_config(), _patch_image_path():
+        with patch.object(LocalImage, "tag", return_value=True) as mock_tag, \
+             patch.object(RegistryImage, "retag") as mock_retag:
+            result = retag_artifacts_image(src_tag="v1.0", target_tag="latest", is_push=False)
+    assert result is True
+    mock_tag.assert_called_once_with(src_tag="v1.0", target_tag="latest")
+    mock_retag.assert_not_called()
+
+
+def test_retag_fails_fast_when_local_fails():
+    with _patch_config(), _patch_image_path():
+        with patch.object(LocalImage, "tag", return_value=False), \
+             patch.object(RegistryImage, "retag") as mock_retag:
+            result = retag_artifacts_image(src_tag="v1.0", target_tag="latest", is_push=True)
+    assert result is False
+    mock_retag.assert_not_called()
+
+
+def test_retag_and_push_calls_both():
+    with _patch_config(), _patch_image_path():
+        with patch.object(LocalImage, "tag", return_value=True), \
+             patch.object(RegistryImage, "configure_auth"), \
+             patch.object(RegistryImage, "retag", return_value=True) as mock_retag:
+            result = retag_artifacts_image(src_tag="v1.0", target_tag="latest", is_push=True)
+    assert result is True
+    mock_retag.assert_called_once_with(src_tag="v1.0", target_tag="latest")
+
+
+# ── prune_artifacts_image ─────────────────────────────────────────────────────
+
+def test_prune_local_only():
+    with _patch_config(), _patch_image_path():
+        with patch.object(LocalImage, "prune", return_value=["v1"]) as mock_prune, \
+             patch.object(RegistryImage, "prune") as mock_reg_prune:
+            result = prune_artifacts_image(keep=2, is_push=False)
+    assert result is True
+    mock_prune.assert_called_once_with(keep=2)
+    mock_reg_prune.assert_not_called()
+
+
+def test_prune_and_push_calls_both():
+    with _patch_config(), _patch_image_path():
+        with patch.object(LocalImage, "prune", return_value=[]), \
+             patch.object(RegistryImage, "configure_auth"), \
+             patch.object(RegistryImage, "prune", return_value=["v1"]) as mock_reg_prune:
+            result = prune_artifacts_image(keep=2, is_push=True)
+    assert result is True
+    mock_reg_prune.assert_called_once_with(keep=2)

--- a/tests/deploy/gcp/test_artifacts_image.py
+++ b/tests/deploy/gcp/test_artifacts_image.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import patch, call
+from unittest.mock import patch
 
 from aigear.common.constant import VENV_BASE_DIR
 from aigear.deploy.gcp.artifacts_image import LocalImage, _validate_dockerfile_venvs

--- a/tests/deploy/gcp/test_artifacts_image.py
+++ b/tests/deploy/gcp/test_artifacts_image.py
@@ -86,29 +86,6 @@ def test_local_remove_correct_command(mock_stream):
     assert cmd == ["docker", "rmi", IMAGE_PATH]
 
 
-# ── ArtifactsImage.image_exist_in_artifacts ──────────────────────────────────
-
-@patch("aigear.deploy.gcp.artifacts_image.run_sh")
-def test_image_exist_returns_true_when_found(mock_run_sh):
-    mock_run_sh.return_value = "digest: sha256:abc"
-    ai = _make_artifacts_image()
-    assert ai.image_exist_in_artifacts() is True
-
-
-@patch("aigear.deploy.gcp.artifacts_image.run_sh")
-def test_image_exist_returns_false_when_not_found(mock_run_sh):
-    mock_run_sh.return_value = "ERROR: Image not found"
-    ai = _make_artifacts_image()
-    assert ai.image_exist_in_artifacts() is False
-
-
-@patch("aigear.deploy.gcp.artifacts_image.run_sh")
-def test_image_exist_returns_false_on_not_found_variant(mock_run_sh):
-    mock_run_sh.return_value = "ERROR: NOT_FOUND: some resource"
-    ai = _make_artifacts_image()
-    assert ai.image_exist_in_artifacts() is False
-
-
 # ── _validate_dockerfile_venvs ────────────────────────────────────────────────
 
 def test_validate_raises_on_venv_base_mismatch(tmp_path):

--- a/tests/deploy/gcp/test_artifacts_image.py
+++ b/tests/deploy/gcp/test_artifacts_image.py
@@ -8,7 +8,6 @@ from aigear.deploy.gcp.artifacts_image import (
     create_artifacts_image,
     delete_artifacts_image,
     retag_artifacts_image,
-    prune_artifacts_image,
     _validate_dockerfile_venvs,
 )
 
@@ -169,77 +168,6 @@ def test_validate_passes_when_no_venv_configured(tmp_path):
         _validate_dockerfile_venvs(str(dockerfile), is_service=False)  # must not raise
 
 
-# ── LocalImage.prune ──────────────────────────────────────────────────────────
-
-DOCKER_IMAGES_OUTPUT = (
-    "v3\t2024-03-01 10:00:00 +0000 UTC\n"
-    "v2\t2024-02-01 10:00:00 +0000 UTC\n"
-    "v1\t2024-01-01 10:00:00 +0000 UTC\n"
-)
-
-
-@patch("aigear.deploy.gcp.artifacts_image.run_sh_stream")
-@patch("aigear.deploy.gcp.artifacts_image.run_sh")
-def test_local_prune_deletes_oldest_beyond_keep(mock_run_sh, mock_stream):
-    mock_run_sh.return_value = DOCKER_IMAGES_OUTPUT
-    mock_stream.return_value = 0
-    deleted = _make_local().prune(keep=2)
-    assert deleted == ["v1"]
-    mock_stream.assert_called_once_with(["docker", "rmi", f"{IMAGE_NAME}:v1"])
-
-
-@patch("aigear.deploy.gcp.artifacts_image.run_sh_stream")
-@patch("aigear.deploy.gcp.artifacts_image.run_sh")
-def test_local_prune_keeps_all_when_keep_exceeds_count(mock_run_sh, mock_stream):
-    mock_run_sh.return_value = DOCKER_IMAGES_OUTPUT
-    deleted = _make_local().prune(keep=10)
-    assert deleted == []
-    mock_stream.assert_not_called()
-
-
-@patch("aigear.deploy.gcp.artifacts_image.run_sh_stream")
-@patch("aigear.deploy.gcp.artifacts_image.run_sh")
-def test_local_prune_keep_1_deletes_all_but_newest(mock_run_sh, mock_stream):
-    mock_run_sh.return_value = DOCKER_IMAGES_OUTPUT
-    mock_stream.return_value = 0
-    deleted = _make_local().prune(keep=1)
-    assert deleted == ["v2", "v1"]
-
-
-@patch("aigear.deploy.gcp.artifacts_image.run_sh_stream")
-@patch("aigear.deploy.gcp.artifacts_image.run_sh")
-def test_local_prune_skips_failed_deletes(mock_run_sh, mock_stream):
-    mock_run_sh.return_value = DOCKER_IMAGES_OUTPUT
-    mock_stream.return_value = 1  # simulate rmi failure
-    deleted = _make_local().prune(keep=1)
-    assert deleted == []
-
-
-@patch("aigear.deploy.gcp.artifacts_image.run_sh")
-def test_local_prune_list_command(mock_run_sh):
-    mock_run_sh.return_value = ""
-    _make_local().prune(keep=1)
-    list_cmd = mock_run_sh.call_args[0][0]
-    assert list_cmd == [
-        "docker", "images", "--format", "{{.Tag}}\t{{.CreatedAt}}", IMAGE_NAME
-    ]
-
-
-@patch("aigear.deploy.gcp.artifacts_image.run_sh_stream")
-@patch("aigear.deploy.gcp.artifacts_image.run_sh")
-def test_local_prune_never_deletes_latest(mock_run_sh, mock_stream):
-    mock_run_sh.return_value = (
-        "latest\t2024-04-01 10:00:00 +0000 UTC\n"
-        "v3\t2024-03-01 10:00:00 +0000 UTC\n"
-        "v2\t2024-02-01 10:00:00 +0000 UTC\n"
-        "v1\t2024-01-01 10:00:00 +0000 UTC\n"
-    )
-    mock_stream.return_value = 0
-    deleted = _make_local().prune(keep=1)
-    assert "latest" not in deleted
-    assert deleted == ["v2", "v1"]
-
-
 def _make_registry() -> RegistryImage:
     return RegistryImage(image_path=IMAGE_PATH)
 
@@ -358,74 +286,6 @@ def test_registry_retag_correct_command(mock_run_sh):
     ]
 
 
-# ── RegistryImage.prune ───────────────────────────────────────────────────────
-
-GCLOUD_TAGS_OUTPUT = "v3\nv2\nv1\n"  # sorted newest-first by gcloud --sort-by=~createTime
-
-
-@patch("aigear.deploy.gcp.artifacts_image.run_sh")
-def test_registry_prune_deletes_oldest_beyond_keep(mock_run_sh):
-    mock_run_sh.side_effect = [
-        GCLOUD_TAGS_OUTPUT,  # list call
-        "Deleted.",           # delete v1
-    ]
-    deleted = _make_registry().prune(keep=2)
-    assert deleted == ["v1"]
-
-
-@patch("aigear.deploy.gcp.artifacts_image.run_sh")
-def test_registry_prune_keeps_all_when_keep_exceeds_count(mock_run_sh):
-    mock_run_sh.return_value = GCLOUD_TAGS_OUTPUT
-    deleted = _make_registry().prune(keep=10)
-    assert deleted == []
-    mock_run_sh.assert_called_once()  # only the list call
-
-
-@patch("aigear.deploy.gcp.artifacts_image.run_sh")
-def test_registry_prune_keep_1_deletes_two(mock_run_sh):
-    mock_run_sh.side_effect = [
-        GCLOUD_TAGS_OUTPUT,
-        "Deleted.",
-        "Deleted.",
-    ]
-    deleted = _make_registry().prune(keep=1)
-    assert deleted == ["v2", "v1"]
-
-
-@patch("aigear.deploy.gcp.artifacts_image.run_sh")
-def test_registry_prune_skips_failed_deletes(mock_run_sh):
-    # keep=1, 3 tags (v3,v2,v1) → delete v2 (fails) and v1 (succeeds)
-    mock_run_sh.side_effect = [GCLOUD_TAGS_OUTPUT, "ERROR: not found", "Deleted."]
-    deleted = _make_registry().prune(keep=1)
-    assert deleted == ["v1"]  # v2 failed but v1 still deleted
-
-
-@patch("aigear.deploy.gcp.artifacts_image.run_sh")
-def test_registry_prune_list_command(mock_run_sh):
-    mock_run_sh.return_value = ""
-    _make_registry().prune(keep=1)
-    list_cmd = mock_run_sh.call_args_list[0][0][0]
-    assert list_cmd == [
-        "gcloud", "artifacts", "docker", "images", "list",
-        IMAGE_NAME,
-        "--include-tags",
-        "--sort-by=~createTime",
-        "--format=value(tags)",
-    ]
-
-
-@patch("aigear.deploy.gcp.artifacts_image.run_sh")
-def test_registry_prune_never_deletes_latest(mock_run_sh):
-    mock_run_sh.side_effect = [
-        "latest\nv3\nv2\nv1\n",  # list call — latest appears first
-        "Deleted.",               # delete v2
-        "Deleted.",               # delete v1
-    ]
-    deleted = _make_registry().prune(keep=1)
-    assert "latest" not in deleted
-    assert deleted == ["v2", "v1"]
-
-
 # ── top-level function helpers ────────────────────────────────────────────────
 
 def _patch_image_path(is_service=False):
@@ -537,23 +397,3 @@ def test_retag_and_push_calls_both():
     mock_retag.assert_called_once_with(src_tag="v1.0", target_tag="latest")
 
 
-# ── prune_artifacts_image ─────────────────────────────────────────────────────
-
-def test_prune_local_only():
-    with _patch_config(), _patch_image_path():
-        with patch.object(LocalImage, "prune", return_value=["v1"]) as mock_prune, \
-             patch.object(RegistryImage, "prune") as mock_reg_prune:
-            result = prune_artifacts_image(keep=2, is_push=False)
-    assert result is True
-    mock_prune.assert_called_once_with(keep=2)
-    mock_reg_prune.assert_not_called()
-
-
-def test_prune_and_push_calls_both():
-    with _patch_config(), _patch_image_path():
-        with patch.object(LocalImage, "prune", return_value=[]), \
-             patch.object(RegistryImage, "configure_auth"), \
-             patch.object(RegistryImage, "prune", return_value=["v1"]) as mock_reg_prune:
-            result = prune_artifacts_image(keep=2, is_push=True)
-    assert result is True
-    mock_reg_prune.assert_called_once_with(keep=2)

--- a/tests/deploy/gcp/test_artifacts_image.py
+++ b/tests/deploy/gcp/test_artifacts_image.py
@@ -307,3 +307,85 @@ def test_registry_delete_correct_command(mock_run_sh):
         "gcloud", "artifacts", "docker", "images", "delete",
         IMAGE_PATH, "--delete-tags", "--quiet",
     ]
+
+
+# ── RegistryImage.retag ───────────────────────────────────────────────────────
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh")
+def test_registry_retag_returns_true_on_success(mock_run_sh):
+    mock_run_sh.return_value = "Created tag."
+    assert _make_registry().retag(src_tag="v1.0", target_tag="latest") is True
+
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh")
+def test_registry_retag_returns_false_on_error(mock_run_sh):
+    mock_run_sh.return_value = "ERROR: tag not found"
+    assert _make_registry().retag(src_tag="v1.0", target_tag="latest") is False
+
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh")
+def test_registry_retag_correct_command(mock_run_sh):
+    mock_run_sh.return_value = "Created tag."
+    _make_registry().retag(src_tag="v1.0", target_tag="latest")
+    cmd = mock_run_sh.call_args[0][0]
+    assert cmd == [
+        "gcloud", "artifacts", "docker", "tags", "add",
+        f"{IMAGE_NAME}:v1.0",
+        f"{IMAGE_NAME}:latest",
+    ]
+
+
+# ── RegistryImage.prune ───────────────────────────────────────────────────────
+
+GCLOUD_TAGS_OUTPUT = "v3\nv2\nv1\n"  # sorted newest-first by gcloud --sort-by=~createTime
+
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh")
+def test_registry_prune_deletes_oldest_beyond_keep(mock_run_sh):
+    mock_run_sh.side_effect = [
+        GCLOUD_TAGS_OUTPUT,  # list call
+        "Deleted.",           # delete v1
+    ]
+    deleted = _make_registry().prune(keep=2)
+    assert deleted == ["v1"]
+
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh")
+def test_registry_prune_keeps_all_when_keep_exceeds_count(mock_run_sh):
+    mock_run_sh.return_value = GCLOUD_TAGS_OUTPUT
+    deleted = _make_registry().prune(keep=10)
+    assert deleted == []
+    mock_run_sh.assert_called_once()  # only the list call
+
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh")
+def test_registry_prune_keep_1_deletes_two(mock_run_sh):
+    mock_run_sh.side_effect = [
+        GCLOUD_TAGS_OUTPUT,
+        "Deleted.",
+        "Deleted.",
+    ]
+    deleted = _make_registry().prune(keep=1)
+    assert deleted == ["v2", "v1"]
+
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh")
+def test_registry_prune_skips_failed_deletes(mock_run_sh):
+    mock_run_sh.side_effect = [GCLOUD_TAGS_OUTPUT, "ERROR: not found"]
+    deleted = _make_registry().prune(keep=1)
+    assert "v3" not in deleted  # v3 is kept
+    assert deleted == []  # failed delete not included
+
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh")
+def test_registry_prune_list_command(mock_run_sh):
+    mock_run_sh.return_value = ""
+    _make_registry().prune(keep=1)
+    list_cmd = mock_run_sh.call_args_list[0][0][0]
+    assert list_cmd == [
+        "gcloud", "artifacts", "docker", "images", "list",
+        IMAGE_NAME,
+        "--include-tags",
+        "--sort-by=~createTime",
+        "--format=value(tags)",
+    ]


### PR DESCRIPTION
## Summary

- Refactor `deploy/gcp/artifacts_image.py`: replace monolithic `ArtifactsImage` with two focused classes — `LocalImage` (wraps `docker` CLI) and `RegistryImage` (wraps `gcloud artifacts` CLI)
- Add `--delete` and `--retag` actions to `aigear-image` CLI alongside the existing `--create`; the three are mutually exclusive
- Promote `--push` to a universal "sync to remote" modifier that works with all three actions (build→push, delete local→delete remote, retag local→retag remote)
- Add `--all` flag to explicitly operate on both `Dockerfile.pl` (pipeline) and `Dockerfile.ms` (service) in one command; without `--all`, operations target a single image
- Infer `is_service` automatically from `--dockerfile_path`: `Dockerfile.ms` → `True`, `Dockerfile.pl` → `False`; `--is_service` is still respected for custom Dockerfile names
- Update `docs/cli-reference.md`, `docs/tutorial.md`, and `docs/route-guide.md` to reflect the new CLI interface

## Motivation

The original `ArtifactsImage` class mixed local Docker and remote GCP concerns in one object and only supported `--create`. Managing images in production requires the full lifecycle (build, delete, re-tag for rollback), and the lack of explicit scope control (`--all`) made fan-out behaviour implicit and error-prone.

## Interface

```bash
# Build both images locally
aigear-image --create --all

# Build and push both images
aigear-image --create --push --all

# Build only the service image (inferred from filename, no --is_service needed)
aigear-image --create --dockerfile_path Dockerfile.ms

# Delete pipeline image locally and from Artifact Registry
aigear-image --delete --push

# Rollback service image in Artifact Registry
aigear-image --retag --src_tag v1.2 --target_tag latest --is_service --push
```

## Test Plan
- [x] pytest tests/deploy/gcp/test_artifacts_image.py — unit tests for LocalImage, RegistryImage, and the four top-level functions
- [x] pytest tests/cli/test_artifacts_image_cli.py — CLI dispatch tests covering --create, --delete, --retag, --all, --is_service, --push, and error paths
- [x] Full suite: pytest — 215 tests, all passing