### PR TITLE
Feat/env schema lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,18 +78,22 @@ my_ml_service/
 
 Copy `env.sample.json` to `env.json` and fill in your GCP project, bucket, service accounts, etc. See the [configuration guide](docs/route-guide.md).
 
-### 3. Create GCP infrastructure
+### 3. Create infrastructure
 
 ```bash
-aigear-gcp-infra --create
+aigear-infra --create
 ```
 
 ### 4. Generate env schema (optional)
 
 ```bash
 aigear-env-schema --generate
-# Force regenerate
+# Force regenerate after env.json changes
 aigear-env-schema --generate --force
+# Show current schema
+aigear-env-schema --show
+# Delete schema
+aigear-env-schema --delete
 ```
 
 Auto-generates a Pydantic model from your `env.json`. This gives you full type hints and IDE auto-complete when reading configuration, so you can navigate from any variable directly back to its definition in `env.json` instead of looking up string keys manually.
@@ -186,12 +190,12 @@ See the full [CLI Reference](docs/cli-reference.md) for all commands and argumen
 | Command | Description |
 |---|---|
 | `aigear-init` | Initialize a new project scaffold |
-| `aigear-gcp-infra` | Provision or tear down GCP infrastructure (buckets, IAM, Pub/Sub, Cloud Build, etc.) |
+| `aigear-infra` | Provision or tear down infrastructure (buckets, IAM, Pub/Sub, Cloud Build, etc.) |
 | `aigear-task` | Run a pipeline step (`workflow`) or start a gRPC model server (`grpc`) |
 | `aigear-scheduler` | Manage Cloud Scheduler jobs (create / update / delete / run / pause / resume) |
 | `aigear-image` | Build and/or push Docker images to Artifact Registry |
 | `aigear-model` | Generate YAML and manage the full lifecycle of a gRPC model service (deploy, update, delete, status) |
-| `aigear-env-schema` | Auto-generate a Pydantic schema from `env.json` |
+| `aigear-env-schema` | Generate, delete, or show the Pydantic schema derived from `env.json` |
 | `aigear-kms-env` | Encrypt or decrypt `env.json` using Cloud KMS |
 
 ---

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -5,7 +5,7 @@ All CLI entry points are installed as standalone commands by `pip install aigear
 | Command | Description |
 |---|---|
 | `aigear-init` | Initialize a new project scaffold |
-| `aigear-gcp-infra` | Create GCP infrastructure (buckets, IAM, Pub/Sub, schedulers) |
+| `aigear-infra` | Create infrastructure (buckets, IAM, Pub/Sub, schedulers) |
 | `aigear-task` | Run a pipeline step or start a gRPC model service |
 | `aigear-scheduler` | Create a Cloud Scheduler job for pipeline steps |
 | `aigear-image` | Build and optionally push Docker images to Artifact Registry |
@@ -261,18 +261,18 @@ aigear-model --version logistic_regression --local --delete
 
 ### `aigear-env-schema`
 
-Auto-generate a Pydantic schema file from the current `env.json`.
+Manage the lifecycle of the Pydantic schema file generated from `env.json`.
 
 ```
-aigear-env-schema [--generate] [--force]
+aigear-env-schema {--generate | --delete | --show} [--force]
 ```
 
 | Argument | Description |
 |---|---|
-| `--generate` | Generate environment schema file. Runs by default if omitted. |
-| `--force` | Regenerate the schema even if one already exists |
-
-> Future commands: `--delete`, `--update`
+| `--generate` | Generate environment schema file from `env.json` |
+| `--delete` | Delete the generated schema file |
+| `--show` | Print the current schema file content |
+| `--force` | Force regenerate even if the schema already exists (used with `--generate`) |
 
 ---
 

--- a/docs/route-guide.md
+++ b/docs/route-guide.md
@@ -338,8 +338,8 @@ All CLI commands read `env.json` from the current working directory.
 | Command | Arguments | Description |
 | :--- | :--- | :--- |
 | `aigear-init` | `--name`, `--pipeline_versions` | Scaffold a new project |
-| `aigear-gcp-infra` | `--create`, `--update`, `--delete`, `--status` | Provision, update, tear down, or query all GCP infrastructure defined in `env.json` |
-| `aigear-env-schema` | `--generate`, `--force` | Auto-generate a Pydantic schema from `env.json` |
+| `aigear-infra` | `--create`, `--update`, `--delete`, `--status` | Provision, update, tear down, or query all infrastructure defined in `env.json` |
+| `aigear-env-schema` | `--generate`, `--delete`, `--show`, `--force` | Manage the lifecycle of the Pydantic schema generated from `env.json` |
 | `aigear-kms-env` | `--encrypt`, `--decrypt`, `--environment`, `--input`, `--output`, `--project-id`, `--location`, `--keyring`, `--key` | Encrypt or decrypt `env.json` using Cloud KMS |
 | `aigear-image` | `--create`, `--delete`, `--retag`, `--push`, `--all`, `--dockerfile_path`, `--build_context`, `--is_service`, `--src_tag`, `--target_tag` | Build, delete, or re-tag Docker images; optionally sync to Artifact Registry |
 | `aigear-scheduler` | `--create`, `--update`, `--delete`, `--status`, `--list`, `--run`, `--pause`, `--resume`, `--version`, `--step_names` | Manage Cloud Scheduler jobs for pipeline steps |

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -187,6 +187,10 @@ Auto-generate a typed Pydantic schema from your `env.json` so all pipeline code 
 aigear-env-schema --generate
 # Force regenerate after env.json changes
 aigear-env-schema --generate --force
+# Show current schema content
+aigear-env-schema --show
+# Delete schema
+aigear-env-schema --delete
 ```
 
 This writes a schema to `config_schema/env_schema.py`. Every pipeline step imports it:
@@ -674,8 +678,8 @@ cp env.sample.json env.json
 # ── Step 3: Generate typed config schema ──────────────────────────────────────
 aigear-env-schema --generate
 
-# ── Step 4: Provision GCP infrastructure (owner-level access required) ────────
-aigear-gcp-infra --create
+# ── Step 4: Provision infrastructure (owner-level access required) ────────────
+aigear-infra --create
 
 # ── Step 5: Implement pipeline code ───────────────────────────────────────────
 # Fill in src/pipelines/logistic_regression/{fetch_data,preprocessing,training,model_service}/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dev = [
 
 [project.scripts]
 aigear-init = "aigear.cli.project_cli:project_init"
-aigear-gcp-infra = "aigear.cli.gcp_cli:gcp_infra"
+aigear-infra = "aigear.cli.gcp_cli:gcp_infra"
 aigear-env-schema = "aigear.cli.env_schema:env_schema"
 aigear-image = "aigear.cli.artifacts_image:docker_image"
 aigear-scheduler = "aigear.cli.gcp_scheduler:gcp_scheduler"

--- a/src/aigear/cli/env_schema.py
+++ b/src/aigear/cli/env_schema.py
@@ -10,9 +10,12 @@ def get_argument() -> argparse.Namespace:
     group.add_argument(
         "--generate", action="store_true", help="Generate environment schema file."
     )
-    # Future commands:
-    # group.add_argument("--delete", action="store_true", help="...")
-    # group.add_argument("--update", action="store_true", help="...")
+    group.add_argument(
+        "--delete", action="store_true", help="Delete the generated environment schema file."
+    )
+    group.add_argument(
+        "--show", action="store_true", help="Print the current environment schema file."
+    )
     parser.add_argument(
         "--force",
         action="store_true",
@@ -25,8 +28,7 @@ def env_schema() -> None:
     args = get_argument()
     if args.generate:
         EnvConfig.generative_env_schema(forced_generate=args.force)
-    # Future commands:
-    # elif args.delete:
-    #     EnvConfig.delete_env_schema()
-    # elif args.update:
-    #     EnvConfig.update_env_schema(forced_generate=args.force)
+    elif args.delete:
+        EnvConfig.delete_env_schema()
+    elif args.show:
+        EnvConfig.show_env_schema()

--- a/src/aigear/common/config.py
+++ b/src/aigear/common/config.py
@@ -137,6 +137,25 @@ class AppConfig:
             forced_generate=forced_generate,
         )
 
+    @classmethod
+    def delete_env_schema(cls) -> None:
+        """Delete the generated env schema file."""
+        output_path = Path.cwd() / "config_schema/env_schema.py"
+        if not output_path.exists():
+            logger.info(f"The 'env_schema' does not exist: {output_path}.")
+            return
+        output_path.unlink()
+        logger.info(f"Deleted 'env_schema': {output_path}.")
+
+    @classmethod
+    def show_env_schema(cls) -> None:
+        """Print the content of the generated env schema file."""
+        output_path = Path.cwd() / "config_schema/env_schema.py"
+        if not output_path.exists():
+            logger.warning(f"The 'env_schema' does not exist: {output_path}.")
+            return
+        print(output_path.read_text(encoding="utf-8"))
+
 
 # ─── Backwards-compatible aliases ────────────────────────────────────────────
 # These allow existing code that imports AigearConfig / PipelinesConfig / EnvConfig
@@ -176,6 +195,15 @@ class EnvConfig:
         logger.info("Generating env schema...")
         AppConfig.generate_env_schema(forced_generate)
         logger.info("Env schema generation complete.")
+
+    @classmethod
+    def delete_env_schema(cls) -> None:
+        logger.info("Deleting env schema...")
+        AppConfig.delete_env_schema()
+
+    @classmethod
+    def show_env_schema(cls) -> None:
+        AppConfig.show_env_schema()
 
 
 # ─── Module-level helpers (backwards compatible) ─────────────────────────────

--- a/tests/cli/test_env_schema_cli.py
+++ b/tests/cli/test_env_schema_cli.py
@@ -1,0 +1,91 @@
+import importlib
+from unittest.mock import patch
+
+import pytest
+
+
+# ── --generate ────────────────────────────────────────────────────────────────
+
+
+def test_generate_calls_generative_env_schema():
+    with patch("sys.argv", ["aigear-env-schema", "--generate"]):
+        import aigear.cli.env_schema as cli_mod
+
+        importlib.reload(cli_mod)
+        with patch("aigear.cli.env_schema.EnvConfig.generative_env_schema") as mock_fn:
+            cli_mod.env_schema()
+    mock_fn.assert_called_once_with(forced_generate=False)
+
+
+def test_generate_force_passes_forced_generate_true():
+    with patch("sys.argv", ["aigear-env-schema", "--generate", "--force"]):
+        import aigear.cli.env_schema as cli_mod
+
+        importlib.reload(cli_mod)
+        with patch("aigear.cli.env_schema.EnvConfig.generative_env_schema") as mock_fn:
+            cli_mod.env_schema()
+    mock_fn.assert_called_once_with(forced_generate=True)
+
+
+# ── --delete ──────────────────────────────────────────────────────────────────
+
+
+def test_delete_calls_delete_env_schema():
+    with patch("sys.argv", ["aigear-env-schema", "--delete"]):
+        import aigear.cli.env_schema as cli_mod
+
+        importlib.reload(cli_mod)
+        with patch("aigear.cli.env_schema.EnvConfig.delete_env_schema") as mock_fn:
+            cli_mod.env_schema()
+    mock_fn.assert_called_once()
+
+
+def test_delete_does_not_call_generate():
+    with patch("sys.argv", ["aigear-env-schema", "--delete"]):
+        import aigear.cli.env_schema as cli_mod
+
+        importlib.reload(cli_mod)
+        with patch("aigear.cli.env_schema.EnvConfig.delete_env_schema"):
+            with patch(
+                "aigear.cli.env_schema.EnvConfig.generative_env_schema"
+            ) as mock_gen:
+                cli_mod.env_schema()
+    mock_gen.assert_not_called()
+
+
+# ── --show ────────────────────────────────────────────────────────────────────
+
+
+def test_show_calls_show_env_schema():
+    with patch("sys.argv", ["aigear-env-schema", "--show"]):
+        import aigear.cli.env_schema as cli_mod
+
+        importlib.reload(cli_mod)
+        with patch("aigear.cli.env_schema.EnvConfig.show_env_schema") as mock_fn:
+            cli_mod.env_schema()
+    mock_fn.assert_called_once()
+
+
+def test_show_does_not_call_generate():
+    with patch("sys.argv", ["aigear-env-schema", "--show"]):
+        import aigear.cli.env_schema as cli_mod
+
+        importlib.reload(cli_mod)
+        with patch("aigear.cli.env_schema.EnvConfig.show_env_schema"):
+            with patch(
+                "aigear.cli.env_schema.EnvConfig.generative_env_schema"
+            ) as mock_gen:
+                cli_mod.env_schema()
+    mock_gen.assert_not_called()
+
+
+# ── no action ─────────────────────────────────────────────────────────────────
+
+
+def test_no_action_exits():
+    with patch("sys.argv", ["aigear-env-schema"]):
+        import aigear.cli.env_schema as cli_mod
+
+        importlib.reload(cli_mod)
+        with pytest.raises(SystemExit):
+            cli_mod.env_schema()

--- a/tests/cli/test_gcp_cli.py
+++ b/tests/cli/test_gcp_cli.py
@@ -3,7 +3,7 @@ from unittest.mock import patch, MagicMock
 
 
 def test_update_flag_calls_infra_update():
-    with patch("sys.argv", ["aigear-gcp-infra", "--update"]):
+    with patch("sys.argv", ["aigear-infra", "--update"]):
         from aigear.cli import gcp_cli
         importlib.reload(gcp_cli)
 
@@ -19,7 +19,7 @@ def test_update_flag_calls_infra_update():
 
 
 def test_create_flag_does_not_call_update():
-    with patch("sys.argv", ["aigear-gcp-infra", "--create"]):
+    with patch("sys.argv", ["aigear-infra", "--create"]):
         from aigear.cli import gcp_cli
         importlib.reload(gcp_cli)
 
@@ -35,7 +35,7 @@ def test_create_flag_does_not_call_update():
 
 
 def test_delete_flag_calls_infra_delete():
-    with patch("sys.argv", ["aigear-gcp-infra", "--delete"]):
+    with patch("sys.argv", ["aigear-infra", "--delete"]):
         from aigear.cli import gcp_cli
         importlib.reload(gcp_cli)
 
@@ -51,7 +51,7 @@ def test_delete_flag_calls_infra_delete():
 
 
 def test_status_flag_calls_infra_status():
-    with patch("sys.argv", ["aigear-gcp-infra", "--status"]):
+    with patch("sys.argv", ["aigear-infra", "--status"]):
         from aigear.cli import gcp_cli
         importlib.reload(gcp_cli)
 


### PR DESCRIPTION
## Summary

- **`aigear-gcp-infra` renamed to `aigear-infra`** in `pyproject.toml` — removes cloud-provider coupling from the CLI entry point name in preparation for multi-cloud support
- **`aigear-env-schema` lifecycle complete** — adds `--delete` and `--show` commands alongside the existing `--generate`/`--force`; backend methods `delete_env_schema` and `show_env_schema` added to both `AppConfig` and `EnvConfig`
- **Docs updated** across `README.md`, `docs/cli-reference.md`, `docs/route-guide.md`, `docs/tutorial.md` to reflect the renamed command and the new CLI flags
- **Tests updated and added** — `test_gcp_cli.py` patched to use the new `aigear-infra` name; new `test_env_schema_cli.py` covers all 7 CLI paths

## Changed files

| File | Change |
|---|---|
| `pyproject.toml` | Rename entry point `aigear-gcp-infra` → `aigear-infra` |
| `src/aigear/cli/env_schema.py` | Add `--delete` and `--show` to the mutually exclusive group |
| `src/aigear/common/config.py` | Add `AppConfig.delete_env_schema`, `AppConfig.show_env_schema`; expose via `EnvConfig` |
| `tests/cli/test_env_schema_cli.py` | New — 7 unit tests covering `--generate`, `--generate --force`, `--delete`, `--show`, no-arg exit |
| `tests/cli/test_gcp_cli.py` | Update `sys.argv` patches from `aigear-gcp-infra` to `aigear-infra` |
| `README.md` / `docs/*` | Sync command names and flag tables |

## Test plan

- [x] `pytest tests/cli/test_env_schema_cli.py` — 7/7 passed
- [x] `aigear-env-schema --generate` generates `config_schema/env_schema.py`
- [x] `aigear-env-schema --show` prints schema content
- [x] `aigear-env-schema --delete` removes schema file
- [x] `aigear-env-schema --generate --force` regenerates when file exists
- [x] `aigear-infra --create` still works (entry point rename only, no logic change)
