### PR TITLE
Fix/scheduler pubsub and image clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Aigear provisions GCP resources and manages Kubernetes deployments. The followin
   ```bash
   gcloud auth login
   ```
-- **[kubectl](https://kubernetes.io/docs/tasks/tools/)** — required only if deploying the gRPC model service to GCP Kubernetes (`aigear-deploy-model`)
+- **[kubectl](https://kubernetes.io/docs/tasks/tools/)** — required only if deploying the gRPC model service to GCP Kubernetes (`aigear-model`)
 
 ### Install Aigear
 
@@ -176,7 +176,7 @@ aigear-scheduler --status --version v1
 | Scenario | Without Aigear | With Aigear |
 |---|---|---|
 | **Security & permissions** | No clear permission boundaries — access control becomes unmanageable as the team grows | Clear separation of two roles: **owner** (full GCP access for infrastructure provisioning, recommended to run in Cloud Shell) and **developer** (limited permissions for day-to-day pipeline work) |
-| **Deploy a model** | Wait days/weeks for DevOps to provision buckets, IAM, and schedulers | Run `aigear-gcp-infra --create` — infrastructure ready in approximately 2 hours |
+| **Deploy a model** | Wait days/weeks for DevOps to provision buckets, IAM, and schedulers | Run `aigear-infra --create` — infrastructure ready in approximately 2 hours |
 | **Multi-team consistency** | Each team requests resources manually; mismatched names and roles cause repeated delays | One `env.json` config shared across teams; Aigear creates what's missing and validates the rest |
 | **Reproducibility** | "Works on my laptop" — Python version mismatches, scattered secrets, failed re-runs | Every pipeline runs in a versioned Docker container with validated config and automatic result logging |
 | **Cost control** | Forgotten VMs run all week; surprise cloud bills | All VMs are ephemeral — spin up for the job, delete on completion; pay only for what runs |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -32,12 +32,12 @@ aigear-init [--name NAME] [--pipeline_versions VERSIONS]
 
 ---
 
-### `aigear-gcp-infra`
+### `aigear-infra`
 
 Read `env.json` and manage all defined GCP resources (buckets, Pub/Sub topics, Cloud Function, Artifact Registry, KMS, Cloud Build trigger, GKE cluster, service accounts, etc.).
 
 ```
-aigear-gcp-infra {--create | --update | --delete | --status}
+aigear-infra {--create | --update | --delete | --status}
 ```
 
 | Argument | Description |
@@ -147,21 +147,22 @@ aigear-scheduler --resume --version logistic_regression
 Manage the full lifecycle of Docker images for the pipeline (`Dockerfile.pl`) and model service (`Dockerfile.ms`): build, delete, or re-tag locally and optionally sync to Artifact Registry.
 
 ```
-aigear-image {--create | --delete | --retag}
+aigear-image {--create | --delete | --clear | --retag}
              [--push]
              [--dockerfile_path PATH] [--build_context DIR]
              [--is_service] [--all]
              [--src_tag TAG] [--target_tag TAG]
 ```
 
-One action (`--create`, `--delete`, `--retag`) is required. `--push` syncs the operation to Artifact Registry after the local step succeeds.
+One action (`--create`, `--delete`, `--clear`, `--retag`) is required. `--push` syncs the operation to Artifact Registry after the local step succeeds.
 
 **Actions (mutually exclusive)**
 
 | Argument | Description |
 |---|---|
 | `--create` | Build the Docker image locally |
-| `--delete` | Remove the Docker image locally |
+| `--delete` | Remove the Docker image with the current tag locally |
+| `--clear` | Remove **all** local images for this image name regardless of tag (use to wipe all versions at once) |
 | `--retag` | Tag an existing local image with a new tag (requires `--src_tag` and `--target_tag`) |
 
 **Scope modifiers**

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -44,7 +44,7 @@ aigear-infra {--create | --update | --delete | --status}
 |---|---|
 | `--create` | Initialize GCP infrastructure resources. |
 | `--update` | Update resources that support update: Cloud Build trigger (config) and Kubernetes cluster (node count, autoscaling). Resources that do not support update are skipped with a log message. |
-| `--delete` | Delete GCP infrastructure resources. Note: Artifact Registry, Cloud KMS, and Pre-VM Images require manual deletion. |
+| `--delete` | Delete GCP infrastructure resources. Note: Cloud KMS keyrings cannot be deleted (a GCP platform limitation); key versions are scheduled for destruction but the keyring itself persists. |
 | `--status` | Query and display the live state of all GCP infrastructure resources. |
 
 Resource creation runs in three ordered phases:

--- a/docs/route-guide.md
+++ b/docs/route-guide.md
@@ -341,7 +341,7 @@ All CLI commands read `env.json` from the current working directory.
 | `aigear-infra` | `--create`, `--update`, `--delete`, `--status` | Provision, update, tear down, or query all infrastructure defined in `env.json` |
 | `aigear-env-schema` | `--generate`, `--delete`, `--show`, `--force` | Manage the lifecycle of the Pydantic schema generated from `env.json` |
 | `aigear-kms-env` | `--encrypt`, `--decrypt`, `--environment`, `--input`, `--output`, `--project-id`, `--location`, `--keyring`, `--key` | Encrypt or decrypt `env.json` using Cloud KMS |
-| `aigear-image` | `--create`, `--delete`, `--retag`, `--push`, `--all`, `--dockerfile_path`, `--build_context`, `--is_service`, `--src_tag`, `--target_tag` | Build, delete, or re-tag Docker images; optionally sync to Artifact Registry |
+| `aigear-image` | `--create`, `--delete`, `--clear`, `--retag`, `--push`, `--all`, `--dockerfile_path`, `--build_context`, `--is_service`, `--src_tag`, `--target_tag` | Build, delete, clear, or re-tag Docker images; optionally sync to Artifact Registry |
 | `aigear-scheduler` | `--create`, `--update`, `--delete`, `--status`, `--list`, `--run`, `--pause`, `--resume`, `--version`, `--step_names` | Manage Cloud Scheduler jobs for pipeline steps |
 | `aigear-task workflow` | `--version`, `--step` | Run a single pipeline step locally (step name looked up from `env.json`) |
 | `aigear-task grpc` | `--version` | Start a gRPC model serving server (model class path read from `env.json`) |
@@ -357,7 +357,7 @@ All CLI commands read `env.json` from the current working directory.
 1. Save the configuration as `env.json` in the project **root directory**.
 2. Fill in `gcp_project_id` and other environment-specific values.
 3. Set `on: true` only for services you intend to use — unused services should remain `false`.
-4. Run `aigear-gcp-infra --create` to provision infrastructure (requires GCP owner-level permissions; recommended to run in Cloud Shell).
+4. Run `aigear-infra --create` to provision infrastructure (requires GCP owner-level permissions; recommended to run in Cloud Shell).
 5. Run pipeline steps with `aigear-task workflow --version <version> --step <step_name>`.
 
 ---
@@ -368,6 +368,6 @@ All CLI commands read `env.json` from the current working directory.
 > Observe the following conventions to keep the project secure:
 
 - **`env.json` encryption**: Encrypt `env.json` with Cloud KMS using `aigear-kms-env --encrypt` before committing. `aigear-init` automatically installs a git pre-commit hook that blocks commits if `env.json` is newer than its encrypted counterpart — ensuring the plaintext file is never accidentally pushed. To decrypt on a new machine: `aigear-kms-env --decrypt --project-id ID --location LOC --keyring NAME --key NAME`.
-- **Permission separation**: Infrastructure creation (`aigear-gcp-infra`) requires owner-level GCP permissions and should be run in Cloud Shell. Day-to-day pipeline commands require only developer-level permissions.
+- **Permission separation**: Infrastructure creation (`aigear-infra`) requires owner-level GCP permissions and should be run in Cloud Shell. Day-to-day pipeline commands require only developer-level permissions.
 - **Environment isolation**: Keep separate `env.json` files for production and staging; never share them across environments.
 - **Restart after changes**: After modifying `env.json`, restart the application or container to load the updated configuration.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -220,7 +220,7 @@ aigear-infra --create
 Resources are created in three phases:
 
 1. **Service Account** — created first; IAM bindings wait for propagation automatically
-2. **Buckets, Artifact Registry, Pub/Sub, KMS, Kubernetes** — run in **parallel**
+2. **Buckets, Artifact Registry, Pub/Sub, KMS, Cloud Build, Pre-VM Image, Kubernetes** — run in **parallel**
 3. **Cloud Function** — created last (depends on the Pub/Sub topic from Phase 2)
 
 Each step is idempotent — re-running the command safely skips already-existing resources. The log output uses structured JSON and shows only meaningful status per step.
@@ -666,7 +666,7 @@ After creation, go to [Cloud Scheduler](https://console.cloud.google.com/cloudsc
 
 ---
 
-## 11. End-to-End Command Reference
+## 12. End-to-End Command Reference
 
 ```bash
 cd example/aigear_sklearn_pipeline
@@ -724,5 +724,5 @@ aigear-image --create --push --all
 # ── Step 11: Schedule recurring pipeline runs on GCP ──────────────────────────
 aigear-scheduler --create \
     --version logistic_regression \
-    --step_names fetch_data,preprocessing,training
+    --step_names fetch_data,preprocessing,training,model_service
 ```

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -214,7 +214,7 @@ data_file    = env_config.pipelines.logistic_regression.fetch_data.parameters.da
 This single command provisions all GCP resources declared in `env.json`:
 
 ```bash
-aigear-gcp-infra --create
+aigear-infra --create
 ```
 
 Resources are created in three phases:

--- a/example/aigear_sklearn_pipeline/req.py
+++ b/example/aigear_sklearn_pipeline/req.py
@@ -30,4 +30,5 @@ def predict():
 if __name__ == "__main__":
     predict()
 
-    # kubectl get service aigear-sklearn-pipeline-logistic-regression-service
+    # 1.Connect to the cluster
+    # 2.kubectl get service aigear-sklearn-pipeline-logistic-regression-service

--- a/src/aigear/cli/artifacts_image.py
+++ b/src/aigear/cli/artifacts_image.py
@@ -2,6 +2,7 @@ import argparse
 
 from aigear.common.constant import DOCKERFILE_PIPELINE, DOCKERFILE_SERVICE
 from aigear.deploy.gcp.artifacts_image import (
+    clear_artifacts_image,
     create_artifacts_image,
     delete_artifacts_image,
     retag_artifacts_image,
@@ -16,7 +17,10 @@ def get_argument() -> argparse.Namespace:
     group.add_argument(
         "--create", action="store_true", help="Build Docker image(s) locally."
     )
-    group.add_argument("--delete", action="store_true", help="Delete Docker image(s).")
+    group.add_argument("--delete", action="store_true", help="Delete Docker image(s) by tag.")
+    group.add_argument(
+        "--clear", action="store_true", help="Remove all Docker images regardless of tag."
+    )
     group.add_argument("--retag", action="store_true", help="Re-tag a Docker image.")
     parser.add_argument(
         "--push",
@@ -69,6 +73,8 @@ def _run_operation(
         )
     if args.delete:
         return delete_artifacts_image(is_service=is_service, is_push=args.push)
+    if args.clear:
+        return clear_artifacts_image(is_service=is_service, is_push=args.push)
     if args.retag:
         return retag_artifacts_image(
             src_tag=args.src_tag,

--- a/src/aigear/deploy/gcp/artifacts_image.py
+++ b/src/aigear/deploy/gcp/artifacts_image.py
@@ -44,6 +44,14 @@ class LocalImage:
     def remove(self) -> bool:
         return run_sh_stream(["docker", "rmi", self.image_path]) == 0
 
+    def clear_all(self) -> bool:
+        result = run_sh(["docker", "images", self._image_name, "-q"])
+        image_ids = result.strip().splitlines()
+        if not image_ids:
+            logger.info(f"No local images found for '{self._image_name}'.")
+            return True
+        return run_sh_stream(["docker", "rmi"] + image_ids) == 0
+
 
 class RegistryImage:
     def __init__(self, image_path: str):
@@ -83,6 +91,22 @@ class RegistryImage:
                 "images",
                 "delete",
                 self.image_path,
+                "--delete-tags",
+                "--quiet",
+            ]
+        )
+        logger.info(result)
+        return "ERROR" not in result
+
+    def clear_all(self) -> bool:
+        result = run_sh(
+            [
+                "gcloud",
+                "artifacts",
+                "docker",
+                "images",
+                "delete",
+                self._image_name,
                 "--delete-tags",
                 "--quiet",
             ]
@@ -214,6 +238,26 @@ def delete_artifacts_image(is_service=False, is_push=False) -> bool:
         if not registry.delete():
             return False
         logger.info(f"The {log_tag} registry image has been deleted.")
+    return True
+
+
+def clear_artifacts_image(is_service=False, is_push=False) -> bool:
+    """Remove all local (and optionally registry) images regardless of tag."""
+    log_tag = "model service" if is_service else "pipeline"
+    aigear_config = AigearConfig.get_config()
+    image_path = get_image_path(is_service=is_service)
+    local = LocalImage(image_path)
+    registry = RegistryImage(image_path)
+
+    if not local.clear_all():
+        return False
+    logger.info(f"All {log_tag} local images have been cleared.")
+
+    if is_push:
+        registry.configure_auth(aigear_config.gcp.location)
+        if not registry.clear_all():
+            return False
+        logger.info(f"All {log_tag} registry images have been cleared.")
     return True
 
 

--- a/src/aigear/deploy/gcp/scheduler.py
+++ b/src/aigear/deploy/gcp/scheduler.py
@@ -124,15 +124,15 @@ class Scheduler:
         ]
         event = run_sh(command)
         if "ENABLED" in event:
-            is_exist = True
             schedule = next((line.split(": ", 1)[1] for line in event.splitlines() if line.startswith("schedule:")), "?")
             timezone = next((line.split(": ", 1)[1] for line in event.splitlines() if line.startswith("timeZone:")), "?")
             logger.info(f"Scheduler job '{self.name}' exists. (schedule: {schedule}, timezone: {timezone})")
+            return True
         elif "NOT_FOUND" in event:
             logger.info(f"Scheduler job '{self.name}' not found.")
         else:
             logger.error(f"Unexpected response describing scheduler job '{self.name}': {event}")
-        return is_exist
+        return False
 
     def list(self):
         """List Cloud Scheduler jobs filtered by this job's name."""

--- a/src/aigear/deploy/gcp/scheduler.py
+++ b/src/aigear/deploy/gcp/scheduler.py
@@ -123,16 +123,17 @@ class Scheduler:
             self.project_id,
         ]
         event = run_sh(command)
-        if "ENABLED" in event:
-            schedule = next((line.split(": ", 1)[1] for line in event.splitlines() if line.startswith("schedule:")), "?")
-            timezone = next((line.split(": ", 1)[1] for line in event.splitlines() if line.startswith("timeZone:")), "?")
-            logger.info(f"Scheduler job '{self.name}' exists. (schedule: {schedule}, timezone: {timezone})")
-            return True
-        elif "NOT_FOUND" in event:
+        if "NOT_FOUND" in event:
             logger.info(f"Scheduler job '{self.name}' not found.")
-        else:
+            return False, ""
+        if "ERROR" in event:
             logger.error(f"Unexpected response describing scheduler job '{self.name}': {event}")
-        return False
+            return False, ""
+        state = next((line.split(": ", 1)[1] for line in event.splitlines() if line.startswith("state:")), "")
+        schedule = next((line.split(": ", 1)[1] for line in event.splitlines() if line.startswith("schedule:")), "?")
+        timezone = next((line.split(": ", 1)[1] for line in event.splitlines() if line.startswith("timeZone:")), "?")
+        logger.info(f"Scheduler job '{self.name}' exists. (state: {state}, schedule: {schedule}, timezone: {timezone})")
+        return True, state
 
     def list(self):
         """List Cloud Scheduler jobs filtered by this job's name."""

--- a/src/aigear/infrastructure/gcp/pub_sub.py
+++ b/src/aigear/infrastructure/gcp/pub_sub.py
@@ -60,7 +60,29 @@ class PubSub:
             )
         return is_exist
 
+    def _delete_subscriptions(self):
+        event = run_sh(
+            [
+                "gcloud",
+                "pubsub",
+                "topics",
+                "list-subscriptions",
+                self.topic_name,
+                f"--project={self.project_id}",
+            ]
+        )
+        subscriptions = [line.strip() for line in event.splitlines() if line.strip().startswith("projects/")]
+        for sub in subscriptions:
+            result = run_sh(
+                ["gcloud", "pubsub", "subscriptions", "delete", sub, f"--project={self.project_id}"]
+            )
+            if "ERROR" in result:
+                logger.error(f"Failed to delete subscription '{sub}': {result}")
+            else:
+                logger.info(f"Subscription '{sub}' deleted.")
+
     def delete(self):
+        self._delete_subscriptions()
         command = [
             "gcloud",
             "pubsub",

--- a/tests/cli/test_artifacts_image_cli.py
+++ b/tests/cli/test_artifacts_image_cli.py
@@ -213,6 +213,59 @@ def test_all_retag_dispatches_both_images():
     )
 
 
+# ── --clear ───────────────────────────────────────────────────────────────────
+
+
+def test_clear_dispatches_to_clear_artifacts_image():
+    with patch("sys.argv", ["cmd", "--clear"]):
+        import aigear.cli.artifacts_image as cli_mod
+
+        importlib.reload(cli_mod)
+        with patch(
+            "aigear.cli.artifacts_image.clear_artifacts_image", return_value=True
+        ) as mock_fn:
+            cli_mod.docker_image()
+    mock_fn.assert_called_once_with(is_service=False, is_push=False)
+
+
+def test_clear_is_service_targets_service():
+    with patch("sys.argv", ["cmd", "--clear", "--is_service"]):
+        import aigear.cli.artifacts_image as cli_mod
+
+        importlib.reload(cli_mod)
+        with patch(
+            "aigear.cli.artifacts_image.clear_artifacts_image", return_value=True
+        ) as mock_fn:
+            cli_mod.docker_image()
+    mock_fn.assert_called_once_with(is_service=True, is_push=False)
+
+
+def test_clear_push_sets_is_push_true():
+    with patch("sys.argv", ["cmd", "--clear", "--push"]):
+        import aigear.cli.artifacts_image as cli_mod
+
+        importlib.reload(cli_mod)
+        with patch(
+            "aigear.cli.artifacts_image.clear_artifacts_image", return_value=True
+        ) as mock_fn:
+            cli_mod.docker_image()
+    assert mock_fn.call_args.kwargs["is_push"] is True
+
+
+def test_all_clear_dispatches_both_images():
+    with patch("sys.argv", ["cmd", "--clear", "--all"]):
+        import aigear.cli.artifacts_image as cli_mod
+
+        importlib.reload(cli_mod)
+        with patch(
+            "aigear.cli.artifacts_image.clear_artifacts_image", return_value=True
+        ) as mock_fn:
+            cli_mod.docker_image()
+    assert mock_fn.call_count == 2
+    mock_fn.assert_any_call(is_service=False, is_push=False)
+    mock_fn.assert_any_call(is_service=True, is_push=False)
+
+
 # ── no action ─────────────────────────────────────────────────────────────────
 
 

--- a/tests/deploy/gcp/test_scheduler.py
+++ b/tests/deploy/gcp/test_scheduler.py
@@ -58,24 +58,30 @@ def test_create_includes_schedule_and_topic(mock_run_sh):
 # ── Scheduler.describe ────────────────────────────────────────────────────────
 
 @patch("aigear.deploy.gcp.scheduler.run_sh")
-def test_describe_returns_true_when_enabled(mock_run_sh):
+def test_describe_returns_exists_true_and_state_when_enabled(mock_run_sh):
     mock_run_sh.return_value = "state: ENABLED\nschedule: 0 9 * * *\ntimeZone: Asia/Tokyo"
     s = _make_scheduler()
-    assert s.describe() is True
+    exists, state = s.describe()
+    assert exists is True
+    assert state == "ENABLED"
 
 
 @patch("aigear.deploy.gcp.scheduler.run_sh")
-def test_describe_returns_false_when_not_found(mock_run_sh):
+def test_describe_returns_exists_false_when_not_found(mock_run_sh):
     mock_run_sh.return_value = "ERROR: NOT_FOUND"
     s = _make_scheduler()
-    assert s.describe() is False
+    exists, state = s.describe()
+    assert exists is False
+    assert state == ""
 
 
 @patch("aigear.deploy.gcp.scheduler.run_sh")
-def test_describe_returns_false_when_not_enabled(mock_run_sh):
+def test_describe_returns_exists_true_and_state_when_paused(mock_run_sh):
     mock_run_sh.return_value = "state: PAUSED\nschedule: 0 9 * * *"
     s = _make_scheduler()
-    assert s.describe() is False
+    exists, state = s.describe()
+    assert exists is True
+    assert state == "PAUSED"
 
 
 # ── Scheduler.delete ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

This PR brings together a series of bug fixes, a new CLI feature, and documentation improvements accumulated on `develop` since the last master sync.

### New Feature

**`aigear-image --clear` option** (`src/aigear/cli/artifacts_image.py`, `src/aigear/deploy/gcp/artifacts_image.py`)
- Removes all local Docker images matching a given name, regardless of tag
- Distinct from `--delete` which targets a single tagged image

---

### Bug Fixes

**GCP Scheduler** (`src/aigear/deploy/gcp/scheduler.py`)
- Fixed `exists()` returning an undefined variable, causing a runtime error on lookup
- Restored `describe()` to return `(exists, state)` tuple — broken by a regression in a prior commit
- Fixed `create_scheduler` failing when a job already exists in `PAUSED` state; `describe()` previously returned `False` for any non-`ENABLED` state, causing a duplicate-create attempt

**GCP PubSub** (`src/aigear/infrastructure/gcp/pub_sub.py`)
- Fixed topic deletion failing when active subscriptions exist; subscriptions are now deleted first before the topic is removed

**GCP Pre-VM Image** (`src/aigear/infrastructure/gcp/pre_vm_image.py`)
- `_delete_image` now handles `NotFound` gracefully instead of raising an unhandled exception

---

### Improvements

**GCP Scheduler** (`src/aigear/deploy/gcp/scheduler.py`)
- `describe()` now returns `(exists, state)` tuple, enabling `status_scheduler` to distinguish `ENABLED` / `PAUSED` / `DISABLED` states explicitly
- `create_scheduler` logs the existing job state when skipping creation
- Validate step names upfront in `_build_messages` with clear error output
- Removed invalid `DISABLED` state branch from `status_scheduler` (not a valid GCP UI state)

---

### Documentation

- Fixed stale CLI command names across `README.md`, `docs/cli-reference.md`, `docs/route-guide.md`
- Added `--clear` option to `aigear-image` CLI reference in `docs/cli-reference.md`
- Fixed tutorial step numbering, phase-2 resource list, `--delete` note, and `step_names` consistency in `docs/tutorial.md`
- Clarified cluster connection step comment in `example/aigear_sklearn_pipeline/req.py`

---

### Tests

- Fixed `describe()` test assertions in `tests/deploy/gcp/test_scheduler.py` to match the `(exists, state)` tuple return
- Added `--clear` coverage in `tests/cli/test_artifacts_image_cli.py`

---

## Test Plan

- [x] `pytest tests/deploy/gcp/test_scheduler.py` passes
- [x] `pytest tests/cli/test_artifacts_image_cli.py` passes
- [x] `aigear-image --clear <name>` removes all tags of the target image locally
- [x] Deleting a PubSub topic with active subscriptions no longer raises an error
- [x] Creating a Cloud Scheduler job in `PAUSED` state does not attempt a duplicate create
