### PR TITLE
fix(deploy): harden LocalImage.clear_all for prune and rmi conflicts

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -162,7 +162,7 @@ One action (`--create`, `--delete`, `--clear`, `--retag`) is required. `--push` 
 |---|---|
 | `--create` | Build the Docker image locally |
 | `--delete` | Remove the Docker image with the current tag locally |
-| `--clear` | Remove **all** local tags for this image repository, then run `docker image prune -f` to reclaim dangling layers (Docker applies this to the whole host, not only this project). Uses `docker rmi -f` with de-duplicated IDs so the same digest referenced by multiple tags or repositories still removes cleanly. With `--push`, also deletes **all** remote tags for that repository in Artifact Registry. |
+| `--clear` | Delete **all** local images for this repository (every tag), then run `docker image prune -f` to clean up dangling images on the host (not limited to this project). With `--push`, also remove that image and **all** its tags from Artifact Registry. |
 | `--retag` | Tag an existing local image with a new tag (requires `--src_tag` and `--target_tag`) |
 
 **Scope modifiers**

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -162,7 +162,7 @@ One action (`--create`, `--delete`, `--clear`, `--retag`) is required. `--push` 
 |---|---|
 | `--create` | Build the Docker image locally |
 | `--delete` | Remove the Docker image with the current tag locally |
-| `--clear` | Remove **all** local images for this image name regardless of tag (use to wipe all versions at once) |
+| `--clear` | Remove **all** local tags for this image repository, then run `docker image prune -f` to reclaim dangling layers (Docker applies this to the whole host, not only this project). Uses `docker rmi -f` with de-duplicated IDs so the same digest referenced by multiple tags or repositories still removes cleanly. With `--push`, also deletes **all** remote tags for that repository in Artifact Registry. |
 | `--retag` | Tag an existing local image with a new tag (requires `--src_tag` and `--target_tag`) |
 
 **Scope modifiers**

--- a/src/aigear/deploy/gcp/artifacts_image.py
+++ b/src/aigear/deploy/gcp/artifacts_image.py
@@ -46,11 +46,20 @@ class LocalImage:
 
     def clear_all(self) -> bool:
         result = run_sh(["docker", "images", self._image_name, "-q"])
-        image_ids = result.strip().splitlines()
-        if not image_ids:
+        raw_ids = [line.strip() for line in result.strip().splitlines() if line.strip()]
+        # One digest can appear on multiple lines (several tags); same ID may also be
+        # tagged under another repository — plain `rmi` errors without `-f`.
+        image_ids = list(dict.fromkeys(raw_ids))
+        if image_ids:
+            if run_sh_stream(["docker", "rmi", "-f"] + image_ids) != 0:
+                return False
+        else:
             logger.info(f"No local images found for '{self._image_name}'.")
-            return True
-        return run_sh_stream(["docker", "rmi"] + image_ids) == 0
+
+        if run_sh_stream(["docker", "image", "prune", "-f"]) != 0:
+            return False
+        logger.info("Pruned dangling local Docker images.")
+        return True
 
 
 class RegistryImage:

--- a/tests/deploy/gcp/test_artifacts_image.py
+++ b/tests/deploy/gcp/test_artifacts_image.py
@@ -93,6 +93,66 @@ def test_local_remove_correct_command(mock_stream):
     assert cmd == ["docker", "rmi", IMAGE_PATH]
 
 
+# ── LocalImage.clear_all ───────────────────────────────────────────────────────
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh_stream")
+@patch("aigear.deploy.gcp.artifacts_image.run_sh")
+def test_local_clear_all_lists_then_rmis_then_prunes(mock_run_sh, mock_stream):
+    mock_run_sh.return_value = "sha1\nsha2\n"
+    mock_stream.return_value = 0
+    assert _make_local().clear_all() is True
+    mock_run_sh.assert_called_once_with(["docker", "images", IMAGE_NAME, "-q"])
+    assert mock_stream.call_count == 2
+    assert mock_stream.call_args_list[0][0][0] == ["docker", "rmi", "-f", "sha1", "sha2"]
+    assert mock_stream.call_args_list[1][0][0] == ["docker", "image", "prune", "-f"]
+
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh_stream")
+@patch("aigear.deploy.gcp.artifacts_image.run_sh")
+def test_local_clear_all_dedupes_repeated_image_ids(mock_run_sh, mock_stream):
+    mock_run_sh.return_value = "sha1\nsha1\nsha2\n"
+    mock_stream.return_value = 0
+    assert _make_local().clear_all() is True
+    assert mock_stream.call_args_list[0][0][0] == ["docker", "rmi", "-f", "sha1", "sha2"]
+
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh_stream")
+@patch("aigear.deploy.gcp.artifacts_image.run_sh")
+def test_local_clear_all_prunes_when_no_local_images(mock_run_sh, mock_stream):
+    mock_run_sh.return_value = ""
+    mock_stream.return_value = 0
+    assert _make_local().clear_all() is True
+    mock_run_sh.assert_called_once_with(["docker", "images", IMAGE_NAME, "-q"])
+    mock_stream.assert_called_once_with(["docker", "image", "prune", "-f"])
+
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh_stream")
+@patch("aigear.deploy.gcp.artifacts_image.run_sh")
+def test_local_clear_all_returns_false_when_rmi_fails(mock_run_sh, mock_stream):
+    mock_run_sh.return_value = "sha1\n"
+    mock_stream.return_value = 1
+    assert _make_local().clear_all() is False
+    mock_stream.assert_called_once_with(["docker", "rmi", "-f", "sha1"])
+
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh_stream")
+@patch("aigear.deploy.gcp.artifacts_image.run_sh")
+def test_local_clear_all_returns_false_when_prune_fails(mock_run_sh, mock_stream):
+    mock_run_sh.return_value = ""
+    mock_stream.return_value = 1
+    assert _make_local().clear_all() is False
+    mock_stream.assert_called_once_with(["docker", "image", "prune", "-f"])
+
+
+@patch("aigear.deploy.gcp.artifacts_image.run_sh_stream")
+@patch("aigear.deploy.gcp.artifacts_image.run_sh")
+def test_local_clear_all_returns_false_when_prune_fails_after_rmi(mock_run_sh, mock_stream):
+    mock_run_sh.return_value = "sha1\n"
+    mock_stream.side_effect = [0, 1]
+    assert _make_local().clear_all() is False
+    assert mock_stream.call_count == 2
+
+
 # ── _validate_dockerfile_venvs ────────────────────────────────────────────────
 
 def test_validate_raises_on_venv_base_mismatch(tmp_path):


### PR DESCRIPTION
Run docker image prune -f after removing tagged images so dangling layers are reclaimed. Use docker rmi -f with deduplicated image IDs so the same digest tagged under multiple repositories no longer fails. Add unit tests for clear_all.