### PR TITLE
Feature/fix subscription

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -52,8 +52,8 @@ Resource creation runs in three ordered phases:
 | Phase | Resources | Mode |
 |---|---|---|
 | 1 | Service Account + IAM bindings | Sequential (must be first) |
-| 2 | Buckets, Artifact Registry, Pub/Sub, KMS, Cloud Build, Pre-VM Image, Kubernetes | **Parallel** |
-| 3 | Cloud Function | Sequential (depends on Pub/Sub from Phase 2) |
+| 2 | Buckets, Artifact Registry, Pub/Sub, KMS, Cloud Build, Pre-VM Image, Kubernetes, Cloud Function (deploy only) | **Parallel** |
+| 3 | Eventarc Pub/Sub trigger | Sequential (requires Pub/Sub topic and Cloud Function from Phase 2) |
 
 - Each step is idempotent — existing resources are detected and skipped.
 - If the GCP default subnet is not yet ready (common in new projects), Pre-VM Image creation retries automatically up to 5 times with a 30-second wait between attempts.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -44,16 +44,28 @@ aigear-infra {--create | --update | --delete | --status}
 |---|---|
 | `--create` | Initialize GCP infrastructure resources. |
 | `--update` | Update resources that support update: Cloud Build trigger (config) and Kubernetes cluster (node count, autoscaling). Resources that do not support update are skipped with a log message. |
-| `--delete` | Delete GCP infrastructure resources. Note: Cloud KMS keyrings cannot be deleted (a GCP platform limitation); key versions are scheduled for destruction but the keyring itself persists. |
-| `--status` | Query and display the live state of all GCP infrastructure resources. |
+| `--delete` | Delete GCP infrastructure resources (see deletion phases below). Note: Cloud KMS keyrings cannot be deleted (a GCP platform limitation); key versions are scheduled for destruction but the keyring itself persists. |
+| `--status` | Query and display the live state of all GCP infrastructure resources (including Eventarc Pub/Sub trigger when applicable). |
 
-Resource creation runs in three ordered phases:
+**`--create`** runs in three ordered phases:
 
 | Phase | Resources | Mode |
 |---|---|---|
 | 1 | Service Account + IAM bindings | Sequential (must be first) |
-| 2 | Buckets, Artifact Registry, Pub/Sub, KMS, Cloud Build, Pre-VM Image, Kubernetes, Cloud Function (deploy only) | **Parallel** |
-| 3 | Eventarc Pub/Sub trigger | Sequential (requires Pub/Sub topic and Cloud Function from Phase 2) |
+| 2 | Buckets, Artifact Registry, Pub/Sub topic, KMS, Cloud Build, Pre-VM Image, Kubernetes, Cloud Function (deploy only, no Pub/Sub trigger) | **Parallel** |
+| 3 | Eventarc Pub/Sub trigger | Sequential (requires Pub/Sub topic **and** Cloud Function from Phase 2) |
+
+Phase 3 runs only when **both** `gcp.pub_sub.on` and `gcp.cloud_function.on` are `true`. The trigger creates the Pub/Sub **subscription** that delivers topic messages to the function (per [Cloud Run Pub/Sub triggers](https://cloud.google.com/run/docs/triggering/pubsub-triggers#gcloud)).
+
+**`--delete`** runs in reverse order:
+
+| Phase | Resources | Mode |
+|---|---|---|
+| 1 | Eventarc Pub/Sub trigger (if both `pub_sub` and `cloud_function` enabled), then Cloud Function | Sequential |
+| 2 | Buckets, Artifact Registry, Pub/Sub topic, KMS, Cloud Build, Pre-VM Image, Kubernetes | **Parallel** |
+| 3 | Service Account | Sequential (last) |
+
+Pub/Sub topic deletion removes any remaining subscriptions on that topic before the topic itself is deleted.
 
 - Each step is idempotent — existing resources are detected and skipped.
 - If the GCP default subnet is not yet ready (common in new projects), Pre-VM Image creation retries automatically up to 5 times with a 30-second wait between attempts.

--- a/docs/route-guide.md
+++ b/docs/route-guide.md
@@ -65,6 +65,8 @@
 | `on` | `boolean` | Enable Cloud Function creation | `true` |
 | `function_name` | `string` | Function name | `test-sklearn-pipeline-run` |
 
+> Deploys a Gen2 function (Cloud Run service) in Phase 2 of `aigear-infra --create` **without** a Pub/Sub trigger. To connect the function to a topic, also enable `pub_sub` so Phase 3 can create an Eventarc Pub/Sub trigger.
+
 #### 2.1.6 IAM (`iam`)
 
 | Parameter | Type | Description | Example |
@@ -78,6 +80,8 @@
 | :--- | :--- | :--- | :--- |
 | `on` | `boolean` | Enable Pub/Sub topic creation | `true` |
 | `topic_name` | `string` | Topic name | `test-sklearn-pipeline-pubsub` |
+
+> Phase 2 creates the **topic** only. A **subscription** (managed by Eventarc) is created in Phase 3 when **both** `pub_sub.on` and `cloud_function.on` are `true`. Cloud Scheduler and other publishers send messages to the topic; the subscription forwards them to the Cloud Function.
 
 #### 2.1.8 Artifact Registry (`artifacts`)
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -220,8 +220,8 @@ aigear-infra --create
 Resources are created in three phases:
 
 1. **Service Account** — created first; IAM bindings wait for propagation automatically
-2. **Buckets, Artifact Registry, Pub/Sub, KMS, Cloud Build, Pre-VM Image, Kubernetes** — run in **parallel**
-3. **Cloud Function** — created last (depends on the Pub/Sub topic from Phase 2)
+2. **Buckets, Artifact Registry, Pub/Sub, KMS, Cloud Build, Pre-VM Image, Kubernetes, Cloud Function** — run in **parallel** (function deploy has no Pub/Sub trigger yet)
+3. **Eventarc Pub/Sub trigger** — created last (requires Pub/Sub topic and Cloud Function from Phase 2; Cloud Function deploy runs in Phase 2 without a trigger)
 
 Each step is idempotent — re-running the command safely skips already-existing resources. The log output uses structured JSON and shows only meaningful status per step.
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -220,8 +220,8 @@ aigear-infra --create
 Resources are created in three phases:
 
 1. **Service Account** — created first; IAM bindings wait for propagation automatically
-2. **Buckets, Artifact Registry, Pub/Sub, KMS, Cloud Build, Pre-VM Image, Kubernetes, Cloud Function** — run in **parallel** (function deploy has no Pub/Sub trigger yet)
-3. **Eventarc Pub/Sub trigger** — created last (requires Pub/Sub topic and Cloud Function from Phase 2; Cloud Function deploy runs in Phase 2 without a trigger)
+2. **Buckets, Artifact Registry, Pub/Sub, KMS, Cloud Build, Pre-VM Image, Kubernetes, Cloud Function** — run in **parallel**
+3. **Eventarc Pub/Sub trigger** — created last
 
 Each step is idempotent — re-running the command safely skips already-existing resources. The log output uses structured JSON and shows only meaningful status per step.
 

--- a/src/aigear/infrastructure/gcp/eventarc.py
+++ b/src/aigear/infrastructure/gcp/eventarc.py
@@ -1,0 +1,125 @@
+import re
+
+from aigear.common import run_sh
+from aigear.common.logger import Logging
+
+logger = Logging(log_name=__name__).console_logging()
+
+_PUBSUB_EVENT = "type=google.cloud.pubsub.topic.v1.messagePublished"
+
+
+def trigger_name_for_function(function_name: str) -> str:
+    """Derive a stable Eventarc trigger ID from the Cloud Function name."""
+    base = re.sub(r"[^a-z0-9-]", "-", function_name.lower())
+    base = re.sub(r"-+", "-", base).strip("-")
+    if not base or not base[0].isalpha():
+        base = f"f-{base}" if base else "f"
+    suffix = "-pubsub"
+    max_base = 63 - len(suffix)
+    return f"{base[:max_base]}{suffix}"
+
+
+class EventarcTrigger:
+    def __init__(
+        self,
+        trigger_name: str,
+        function_name: str,
+        region: str,
+        topic_name: str,
+        project_id: str,
+        trigger_service_account: str,
+    ):
+        self.trigger_name = trigger_name
+        self.function_name = function_name
+        self.region = region
+        self.topic_name = topic_name
+        self.project_id = project_id
+        self.trigger_service_account = trigger_service_account
+        self.transport_topic = f"projects/{project_id}/topics/{topic_name}"
+
+    @classmethod
+    def from_function(
+        cls,
+        function_name: str,
+        region: str,
+        topic_name: str,
+        project_id: str,
+        trigger_service_account: str,
+    ) -> "EventarcTrigger":
+        return cls(
+            trigger_name=trigger_name_for_function(function_name),
+            function_name=function_name,
+            region=region,
+            topic_name=topic_name,
+            project_id=project_id,
+            trigger_service_account=trigger_service_account,
+        )
+
+    def describe(self) -> bool:
+        command = [
+            "gcloud",
+            "eventarc",
+            "triggers",
+            "describe",
+            self.trigger_name,
+            f"--location={self.region}",
+            f"--project={self.project_id}",
+        ]
+        event = run_sh(command)
+        if f"projects/{self.project_id}/locations/{self.region}/triggers/{self.trigger_name}" in event:
+            return True
+        if "name: projects" in event and self.trigger_name in event:
+            return True
+        if "ERROR" in event and "NOT_FOUND" not in event:
+            logger.error(
+                f"Unexpected error describing Eventarc trigger ({self.trigger_name}): {event}"
+            )
+        return False
+
+    def create(self):
+        command = [
+            "gcloud",
+            "eventarc",
+            "triggers",
+            "create",
+            self.trigger_name,
+            f"--location={self.region}",
+            f"--destination-run-service={self.function_name}",
+            f"--destination-run-region={self.region}",
+            f"--event-filters={_PUBSUB_EVENT}",
+            f"--transport-topic={self.transport_topic}",
+            f"--service-account={self.trigger_service_account}",
+            f"--project={self.project_id}",
+        ]
+        run_sh(command, check=True)
+
+    def add_permissions(self, sa_email: str):
+        command = [
+            "gcloud",
+            "projects",
+            "add-iam-policy-binding",
+            self.project_id,
+            f"--member=serviceAccount:{sa_email}",
+            "--role=roles/eventarc.eventReceiver",
+        ]
+        run_sh(command, check=True)
+        logger.info(f"✅ eventarc.eventReceiver granted for {sa_email}")
+
+    def delete(self):
+        command = [
+            "gcloud",
+            "eventarc",
+            "triggers",
+            "delete",
+            self.trigger_name,
+            f"--location={self.region}",
+            f"--project={self.project_id}",
+            "--quiet",
+        ]
+        event = run_sh(command)
+        if "ERROR" in event and "NOT_FOUND" not in event:
+            logger.error(
+                f"Failed to delete Eventarc trigger ({self.trigger_name}): {event}"
+            )
+        else:
+            logger.info(f"Eventarc trigger '{self.trigger_name}' deleted.")

--- a/src/aigear/infrastructure/gcp/eventarc.py
+++ b/src/aigear/infrastructure/gcp/eventarc.py
@@ -1,3 +1,5 @@
+import time
+
 from aigear.common import run_sh
 from aigear.common.logger import Logging
 
@@ -38,25 +40,115 @@ class EventarcPubSubTrigger:
     def transport_topic(self) -> str:
         return f"projects/{self.project_id}/topics/{self.topic_name}"
 
-    def describe(self) -> bool:
-        command = [
-            "gcloud",
-            "eventarc",
-            "triggers",
-            "describe",
-            self.trigger_name,
-            f"--location={self.location}",
-            f"--project={self.project_id}",
-        ]
-        event = run_sh(command)
+    @staticmethod
+    def _parse_gcloud_values(event: str) -> list[str]:
+        text = event.strip()
+        if not text:
+            return []
+        if "\t" in text:
+            return [p.strip() for p in text.split("\t")]
+        return [p.strip() for p in text.splitlines() if p.strip()]
+
+    def _describe_transport(self) -> tuple[bool, str | None]:
+        """Whether the trigger exists and its transport subscription path."""
+        event = run_sh(
+            [
+                "gcloud",
+                "eventarc",
+                "triggers",
+                "describe",
+                self.trigger_name,
+                f"--location={self.location}",
+                f"--project={self.project_id}",
+                "--format=value(name,transport.pubsub.subscription)",
+            ]
+        )
         if "ERROR" in event:
             if "NOT_FOUND" not in event:
                 logger.error(
                     f"Unexpected error describing Eventarc trigger "
                     f"({self.trigger_name}): {event}"
                 )
-            return False
-        return "name:" in event
+            return False, None
+        parts = self._parse_gcloud_values(event)
+        if not parts:
+            return False, None
+        transport_sub = (
+            parts[1] if len(parts) > 1 and parts[1].startswith("projects/") else None
+        )
+        return True, transport_sub
+
+    def describe(self) -> bool:
+        return self._describe_transport()[0]
+
+    def _subscription_candidates(self, pubsub, transport_sub: str | None) -> list[str]:
+        """Subscriptions to inspect via pubsub subscriptions describe."""
+        candidates: list[str] = []
+        if transport_sub:
+            candidates.append(transport_sub)
+        candidates.extend(pubsub.list_subscriptions())
+        prefix = f"eventarc-{self.location}-{self.trigger_name}-sub-"
+        event = run_sh(
+            [
+                "gcloud",
+                "pubsub",
+                "subscriptions",
+                "list",
+                f"--project={self.project_id}",
+                f"--filter=name:{prefix}",
+                "--uri",
+            ]
+        )
+        for line in event.splitlines():
+            sub = line.strip()
+            if sub.startswith("projects/") and sub not in candidates:
+                candidates.append(sub)
+        return candidates
+
+    def _is_ready(self, pubsub, transport_sub: str | None) -> bool:
+        return pubsub.find_healthy_subscription(
+            self._subscription_candidates(pubsub, transport_sub)
+        ) is not None
+
+    def _delete_orphan_subscriptions(self, pubsub, transport_sub: str | None):
+        candidates = self._subscription_candidates(pubsub, transport_sub)
+        for sub in pubsub.find_orphan_subscriptions(candidates):
+            bound = pubsub.describe_subscription(sub)
+            logger.warning(
+                f"Deleting orphan subscription ({sub.rsplit('/', 1)[-1]}): "
+                f"bound to {bound or 'deleted/unknown topic'}, "
+                f"expected {pubsub.topic_path}"
+            )
+            pubsub.delete_subscription(sub)
+        if transport_sub and pubsub.subscription_status(transport_sub) == "missing":
+            logger.info(
+                f"Trigger subscription ({transport_sub.rsplit('/', 1)[-1]}) "
+                f"does not exist."
+            )
+
+    def _wait_for_ready(
+        self, pubsub, transport_sub: str | None, retries: int = 20, interval: float = 1.0
+    ) -> bool:
+        for i in range(retries + 1):
+            _, current_sub = self._describe_transport()
+            check_sub = current_sub or transport_sub
+            if self._is_ready(pubsub, check_sub):
+                healthy = pubsub.find_healthy_subscription(
+                    self._subscription_candidates(pubsub, check_sub)
+                )
+                logger.info(
+                    f"Eventarc subscription ready: {healthy.rsplit('/', 1)[-1]}"
+                )
+                return True
+            if i == retries:
+                break
+            if i == 0 or (i + 1) % 5 == 0:
+                logger.info(
+                    f"Waiting for healthy subscription on topic ({self.topic_name}) "
+                    f"... ({i + 1}/{retries})"
+                )
+            time.sleep(interval)
+        return False
 
     def create(self):
         command = [
@@ -75,7 +167,7 @@ class EventarcPubSubTrigger:
         ]
         run_sh(command, check=True)
 
-    def delete(self):
+    def delete(self) -> bool:
         command = [
             "gcloud",
             "eventarc",
@@ -91,8 +183,9 @@ class EventarcPubSubTrigger:
             logger.error(
                 f"Failed to delete Eventarc trigger ({self.trigger_name}): {event}"
             )
-        else:
-            logger.info(f"Eventarc trigger '{self.trigger_name}' deleted.")
+            return False
+        logger.info(f"Eventarc trigger '{self.trigger_name}' deleted.")
+        return True
 
     def _grant_event_receiver(self):
         command = [
@@ -111,18 +204,49 @@ class EventarcPubSubTrigger:
         """Create Pub/Sub Eventarc trigger if missing; verify topic has a subscription."""
         from aigear.infrastructure.gcp.pub_sub import PubSub
 
-        if not self.describe():
+        pubsub = PubSub(self.topic_name, self.project_id)
+        trigger_exists, transport_sub = self._describe_transport()
+
+        if trigger_exists and self._is_ready(pubsub, transport_sub):
+            healthy = pubsub.find_healthy_subscription(
+                self._subscription_candidates(pubsub, transport_sub)
+            )
+            logger.info(
+                f"Eventarc trigger ({self.trigger_name}) already ready "
+                f"(subscription {healthy.rsplit('/', 1)[-1]} on {self.topic_name})."
+            )
+            return
+
+        recreated = False
+        if trigger_exists:
+            logger.warning(
+                f"Orphaned Eventarc trigger ({self.trigger_name}): no healthy "
+                f"subscription on topic ({self.topic_name}). Cleaning up..."
+            )
+            self._delete_orphan_subscriptions(pubsub, transport_sub)
+            if not self.delete():
+                raise RuntimeError(
+                    f"Failed to delete orphaned Eventarc trigger "
+                    f"({self.trigger_name})."
+                )
+            recreated = True
+            trigger_exists = False
+
+        if not trigger_exists:
+            if not recreated:
+                self._delete_orphan_subscriptions(pubsub, None)
             logger.info(
                 f"Creating Eventarc trigger ({self.trigger_name}) for topic "
                 f"({self.topic_name})..."
             )
-            self._grant_event_receiver()
+            if not recreated:
+                self._grant_event_receiver()
             self.create()
-        if not PubSub(self.topic_name, self.project_id).has_subscriptions():
-            raise RuntimeError(
-                f"Pub/Sub topic ({self.topic_name}) has no subscription after "
-                f"Eventarc trigger ({self.trigger_name}) setup."
-            )
+            if not self._wait_for_ready(pubsub, None):
+                raise RuntimeError(
+                    f"No healthy Pub/Sub subscription on topic ({self.topic_name}) "
+                    f"after Eventarc trigger ({self.trigger_name}) setup."
+                )
 
     def delete_if_exists(self):
         if self.describe():

--- a/src/aigear/infrastructure/gcp/eventarc.py
+++ b/src/aigear/infrastructure/gcp/eventarc.py
@@ -1,59 +1,42 @@
-import re
-
 from aigear.common import run_sh
 from aigear.common.logger import Logging
 
 logger = Logging(log_name=__name__).console_logging()
 
-_PUBSUB_EVENT = "type=google.cloud.pubsub.topic.v1.messagePublished"
+
+def pubsub_trigger_name(function_name: str) -> str:
+    """Stable Eventarc trigger id for a Cloud Function Pub/Sub binding."""
+    return f"{function_name}-pubsub"
 
 
-def trigger_name_for_function(function_name: str) -> str:
-    """Derive a stable Eventarc trigger ID from the Cloud Function name."""
-    base = re.sub(r"[^a-z0-9-]", "-", function_name.lower())
-    base = re.sub(r"-+", "-", base).strip("-")
-    if not base or not base[0].isalpha():
-        base = f"f-{base}" if base else "f"
-    suffix = "-pubsub"
-    max_base = 63 - len(suffix)
-    return f"{base[:max_base]}{suffix}"
+class EventarcPubSubTrigger:
+    """
+    Eventarc Pub/Sub trigger for a Cloud Run (Gen2) function.
 
+    See: https://cloud.google.com/run/docs/triggering/pubsub-triggers#gcloud
+    """
 
-class EventarcTrigger:
     def __init__(
         self,
         trigger_name: str,
-        function_name: str,
-        region: str,
-        topic_name: str,
+        location: str,
         project_id: str,
+        function_name: str,
+        function_region: str,
+        topic_name: str,
         trigger_service_account: str,
     ):
         self.trigger_name = trigger_name
-        self.function_name = function_name
-        self.region = region
-        self.topic_name = topic_name
+        self.location = location
         self.project_id = project_id
+        self.function_name = function_name
+        self.function_region = function_region
+        self.topic_name = topic_name
         self.trigger_service_account = trigger_service_account
-        self.transport_topic = f"projects/{project_id}/topics/{topic_name}"
 
-    @classmethod
-    def from_function(
-        cls,
-        function_name: str,
-        region: str,
-        topic_name: str,
-        project_id: str,
-        trigger_service_account: str,
-    ) -> "EventarcTrigger":
-        return cls(
-            trigger_name=trigger_name_for_function(function_name),
-            function_name=function_name,
-            region=region,
-            topic_name=topic_name,
-            project_id=project_id,
-            trigger_service_account=trigger_service_account,
-        )
+    @property
+    def transport_topic(self) -> str:
+        return f"projects/{self.project_id}/topics/{self.topic_name}"
 
     def describe(self) -> bool:
         command = [
@@ -62,19 +45,18 @@ class EventarcTrigger:
             "triggers",
             "describe",
             self.trigger_name,
-            f"--location={self.region}",
+            f"--location={self.location}",
             f"--project={self.project_id}",
         ]
         event = run_sh(command)
-        if f"projects/{self.project_id}/locations/{self.region}/triggers/{self.trigger_name}" in event:
-            return True
-        if "name: projects" in event and self.trigger_name in event:
-            return True
-        if "ERROR" in event and "NOT_FOUND" not in event:
-            logger.error(
-                f"Unexpected error describing Eventarc trigger ({self.trigger_name}): {event}"
-            )
-        return False
+        if "ERROR" in event:
+            if "NOT_FOUND" not in event:
+                logger.error(
+                    f"Unexpected error describing Eventarc trigger "
+                    f"({self.trigger_name}): {event}"
+                )
+            return False
+        return "name:" in event
 
     def create(self):
         command = [
@@ -83,27 +65,15 @@ class EventarcTrigger:
             "triggers",
             "create",
             self.trigger_name,
-            f"--location={self.region}",
+            f"--location={self.location}",
             f"--destination-run-service={self.function_name}",
-            f"--destination-run-region={self.region}",
-            f"--event-filters={_PUBSUB_EVENT}",
+            f"--destination-run-region={self.function_region}",
+            '--event-filters=type=google.cloud.pubsub.topic.v1.messagePublished',
             f"--transport-topic={self.transport_topic}",
             f"--service-account={self.trigger_service_account}",
             f"--project={self.project_id}",
         ]
         run_sh(command, check=True)
-
-    def add_permissions(self, sa_email: str):
-        command = [
-            "gcloud",
-            "projects",
-            "add-iam-policy-binding",
-            self.project_id,
-            f"--member=serviceAccount:{sa_email}",
-            "--role=roles/eventarc.eventReceiver",
-        ]
-        run_sh(command, check=True)
-        logger.info(f"✅ eventarc.eventReceiver granted for {sa_email}")
 
     def delete(self):
         command = [
@@ -112,14 +82,28 @@ class EventarcTrigger:
             "triggers",
             "delete",
             self.trigger_name,
-            f"--location={self.region}",
+            f"--location={self.location}",
             f"--project={self.project_id}",
             "--quiet",
         ]
         event = run_sh(command)
-        if "ERROR" in event and "NOT_FOUND" not in event:
+        if "ERROR" in event:
             logger.error(
                 f"Failed to delete Eventarc trigger ({self.trigger_name}): {event}"
             )
         else:
             logger.info(f"Eventarc trigger '{self.trigger_name}' deleted.")
+
+    def add_trigger_permissions(self):
+        """Grant eventarc.eventReceiver on the project for the trigger identity."""
+        command = [
+            "gcloud",
+            "projects",
+            "add-iam-policy-binding",
+            self.project_id,
+            f"--member=serviceAccount:{self.trigger_service_account}",
+            "--role=roles/eventarc.eventReceiver",
+            "--condition=None",
+        ]
+        run_sh(command, check=True)
+        logger.info("✅ Successfully granted: roles/eventarc.eventReceiver")

--- a/src/aigear/infrastructure/gcp/eventarc.py
+++ b/src/aigear/infrastructure/gcp/eventarc.py
@@ -94,8 +94,7 @@ class EventarcPubSubTrigger:
         else:
             logger.info(f"Eventarc trigger '{self.trigger_name}' deleted.")
 
-    def add_trigger_permissions(self):
-        """Grant eventarc.eventReceiver on the project for the trigger identity."""
+    def _grant_event_receiver(self):
         command = [
             "gcloud",
             "projects",
@@ -107,3 +106,28 @@ class EventarcPubSubTrigger:
         ]
         run_sh(command, check=True)
         logger.info("✅ Successfully granted: roles/eventarc.eventReceiver")
+
+    def ensure(self):
+        """Create Pub/Sub Eventarc trigger if missing; verify topic has a subscription."""
+        from aigear.infrastructure.gcp.pub_sub import PubSub
+
+        if not self.describe():
+            logger.info(
+                f"Creating Eventarc trigger ({self.trigger_name}) for topic "
+                f"({self.topic_name})..."
+            )
+            self._grant_event_receiver()
+            self.create()
+        if not PubSub(self.topic_name, self.project_id).has_subscriptions():
+            raise RuntimeError(
+                f"Pub/Sub topic ({self.topic_name}) has no subscription after "
+                f"Eventarc trigger ({self.trigger_name}) setup."
+            )
+
+    def delete_if_exists(self):
+        if self.describe():
+            self.delete()
+        else:
+            logger.info(
+                f"Eventarc trigger ({self.trigger_name}) not found. Skipping."
+            )

--- a/src/aigear/infrastructure/gcp/eventarc.py
+++ b/src/aigear/infrastructure/gcp/eventarc.py
@@ -5,6 +5,10 @@ from aigear.common.logger import Logging
 
 logger = Logging(log_name=__name__).console_logging()
 
+# Align with master --trigger-topic: long enough for VM insert + function return.
+PUSH_ACK_DEADLINE_SEC = 300
+PUSH_MIN_RETRY_DELAY_SEC = 60
+
 
 def pubsub_trigger_name(function_name: str) -> str:
     """Stable Eventarc trigger id for a Cloud Function Pub/Sub binding."""
@@ -110,6 +114,17 @@ class EventarcPubSubTrigger:
             self._subscription_candidates(pubsub, transport_sub)
         ) is not None
 
+    def _tune_push_subscription(self, pubsub, transport_sub: str | None):
+        healthy = pubsub.find_healthy_subscription(
+            self._subscription_candidates(pubsub, transport_sub)
+        )
+        if healthy:
+            pubsub.tune_push_subscription(
+                healthy,
+                ack_deadline_sec=PUSH_ACK_DEADLINE_SEC,
+                min_retry_delay_sec=PUSH_MIN_RETRY_DELAY_SEC,
+            )
+
     def _delete_orphan_subscriptions(self, pubsub, transport_sub: str | None):
         candidates = self._subscription_candidates(pubsub, transport_sub)
         for sub in pubsub.find_orphan_subscriptions(candidates):
@@ -211,6 +226,7 @@ class EventarcPubSubTrigger:
             healthy = pubsub.find_healthy_subscription(
                 self._subscription_candidates(pubsub, transport_sub)
             )
+            self._tune_push_subscription(pubsub, transport_sub)
             logger.info(
                 f"Eventarc trigger ({self.trigger_name}) already ready "
                 f"(subscription {healthy.rsplit('/', 1)[-1]} on {self.topic_name})."
@@ -247,6 +263,7 @@ class EventarcPubSubTrigger:
                     f"No healthy Pub/Sub subscription on topic ({self.topic_name}) "
                     f"after Eventarc trigger ({self.trigger_name}) setup."
                 )
+            self._tune_push_subscription(pubsub, None)
 
     def delete_if_exists(self):
         if self.describe():

--- a/src/aigear/infrastructure/gcp/function.py
+++ b/src/aigear/infrastructure/gcp/function.py
@@ -32,20 +32,19 @@ class CloudFunction:
 
         function_path_src = source_path / "index.js"
         function_file_dst = destination_path / "index.js"
-        if not function_file_dst.exists():
-            content = Path(function_path_src).read_text(encoding="utf-8")
-            content = (
-                content.replace("{{PROJECTID}}", self.project_id)
-                .replace("{{REGION}}", self.region)
-                .replace("{{TOPICSNAME}}", self.topic_name)
-                .replace("{{VENVBASEDIR}}", VENV_BASE_DIR)
-            )
-            function_file_dst.write_text(content, encoding="utf-8")
+        # Always rewrite rendered source so local cache does not keep stale config/code.
+        content = Path(function_path_src).read_text(encoding="utf-8")
+        content = (
+            content.replace("{{PROJECTID}}", self.project_id)
+            .replace("{{REGION}}", self.region)
+            .replace("{{TOPICSNAME}}", self.topic_name)
+            .replace("{{VENVBASEDIR}}", VENV_BASE_DIR)
+        )
+        function_file_dst.write_text(content, encoding="utf-8")
 
         package_file_src = source_path / "package.json"
         package_file_dst = destination_path / "package.json"
-        if not package_file_dst.exists():
-            shutil.copy(package_file_src, package_file_dst)
+        shutil.copy(package_file_src, package_file_dst)
 
         return destination_path.as_posix()
 
@@ -63,6 +62,8 @@ class CloudFunction:
             f"--source={source_path}",
             f"--project={self.project_id}",
             f"--service-account={self.service_account}",
+            # Gen2 requires a trigger when creating a new function.
+            "--trigger-http",
             "--quiet",
             "--no-allow-unauthenticated",
         ]

--- a/src/aigear/infrastructure/gcp/function.py
+++ b/src/aigear/infrastructure/gcp/function.py
@@ -7,6 +7,9 @@ from aigear.common.logger import Logging
 
 logger = Logging(log_name=__name__).console_logging()
 
+# Must be >= Pub/Sub push ack deadline (see eventarc.PUSH_ACK_DEADLINE_SEC).
+REQUEST_TIMEOUT_SEC = 300
+
 
 class CloudFunction:
     def __init__(
@@ -64,10 +67,31 @@ class CloudFunction:
             f"--service-account={self.service_account}",
             # Gen2 requires a trigger when creating a new function.
             "--trigger-http",
+            f"--timeout={REQUEST_TIMEOUT_SEC}s",
             "--quiet",
             "--no-allow-unauthenticated",
         ]
         run_sh(command, timeout=600, check=True)
+
+    def _ensure_request_timeout(self):
+        run_sh(
+            [
+                "gcloud",
+                "run",
+                "services",
+                "update",
+                self.function_name,
+                f"--region={self.region}",
+                f"--project={self.project_id}",
+                f"--timeout={REQUEST_TIMEOUT_SEC}",
+                "--quiet",
+            ],
+            check=True,
+        )
+        logger.info(
+            f"Cloud Function ({self.function_name}) request timeout "
+            f"set to {REQUEST_TIMEOUT_SEC}s"
+        )
 
     def ensure(self, invoker_sa_email: str):
         """Deploy if missing, then ensure run.invoker for the trigger identity."""
@@ -76,6 +100,8 @@ class CloudFunction:
                 f"Deploying Cloud Function ({self.function_name}) in {self.region}..."
             )
             self.deploy()
+        else:
+            self._ensure_request_timeout()
         self.add_permissions_to_cloud_function(sa_email=invoker_sa_email)
 
     def add_permissions_to_cloud_function(self, sa_email):

--- a/src/aigear/infrastructure/gcp/function.py
+++ b/src/aigear/infrastructure/gcp/function.py
@@ -68,6 +68,15 @@ class CloudFunction:
         ]
         run_sh(command, timeout=600, check=True)
 
+    def ensure(self, invoker_sa_email: str):
+        """Deploy if missing, then ensure run.invoker for the trigger identity."""
+        if not self.describe():
+            logger.info(
+                f"Deploying Cloud Function ({self.function_name}) in {self.region}..."
+            )
+            self.deploy()
+        self.add_permissions_to_cloud_function(sa_email=invoker_sa_email)
+
     def add_permissions_to_cloud_function(self, sa_email):
         command = [
             "gcloud",

--- a/src/aigear/infrastructure/gcp/function.py
+++ b/src/aigear/infrastructure/gcp/function.py
@@ -60,7 +60,6 @@ class CloudFunction:
             "--runtime=nodejs24",
             f"--region={self.region}",
             f"--entry-point={self.entry_point}",
-            f"--trigger-topic={self.topic_name}",
             f"--source={source_path}",
             f"--project={self.project_id}",
             f"--service-account={self.service_account}",

--- a/src/aigear/infrastructure/gcp/function/index.js
+++ b/src/aigear/infrastructure/gcp/function/index.js
@@ -55,6 +55,13 @@ const EXHAUSTED_CODES = [
   'acceleratorTypes',   // GPU type absent from a zone (404)
 ];
 
+// Non-retryable VM errors — retrying other zones or redelivering the message cannot help
+const FATAL_VM_ERROR_CODES = [
+  'NOT_FOUND',
+  'INVALID_ARGUMENT',
+  'INVALID_ARG_VALUE',
+];
+
 // ─── Utilities ────────────────────────────────────────────────────────────────
 
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
@@ -161,23 +168,32 @@ function buildStartupScript({ dockerImage, gpuFlag, pipelineCommand, yamlPathInI
   // Single-quote-escape all values interpolated into shell to prevent injection
   const esc = s => s.replace(/'/g, "'\\''");
 
+  // Shared handler: publish terminal error to Pub/Sub and delete this VM.
+  const fatalErrorFn = `
+# Publish a terminal error and delete this VM (stops the Pub/Sub pipeline).
+fatal_error() {
+  local exit_code="$1"
+  gcloud pubsub topics publish '${esc(topicName)}' --message '{"error":true,"exit_code":"'"$exit_code"'"}' || true
+  gcp_zone=$(curl -sf -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/zone | cut -d/ -f4)
+  sleep ${CONFIG.vm.sleepBeforeDelete}
+  gcloud compute instances delete "$(hostname | cut -d. -f1)" --zone "$gcp_zone" --quiet
+  exit 1
+}
+`;
+
   // ── Pipeline step ────────────────────────────────────────────────────────────
   // A pipeline failure is fatal: publish an error message, then delete the VM.
   const runPipeline = pipelineCommand ? `
 # ── Pipeline step ──
-docker run ${gpuFlag} '${esc(dockerImage)}' ${pipelineCommand}
-docker_exit_code=$?
+docker_exit_code=0
+docker run ${gpuFlag} '${esc(dockerImage)}' ${pipelineCommand} || docker_exit_code=$?
 if [ "$docker_exit_code" -ne 0 ]; then
-  gcloud pubsub topics publish '${esc(topicName)}' --message '{"error":true,"exit_code":"'"$docker_exit_code"'"}'
-  gcp_zone=$(curl -sf -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/zone | cut -d/ -f4)
-  sleep 10
-  gcloud compute instances delete "$(hostname | cut -d. -f1)" --zone "$gcp_zone" --quiet
-  exit 1
+  fatal_error pipeline_failed
 fi
 ` : '';
 
   // ── Deploy step ──────────────────────────────────────────────────────────────
-  // A deploy failure is non-fatal: log it and continue the pipeline.
+  // A deploy failure is fatal: publish an error message, then delete the VM.
   //
   // gcloud + kubectl are pre-installed in the custom VM image, so no installation needed.
   //
@@ -187,21 +203,35 @@ fi
   //      GKE_CLUSTER / GKE_ZONE / GKE_PROJECT must be set as VM metadata or env vars
   //   3. kubectl apply                                     — deploy to the cluster
   //
-  // "cmd || deploy_exit_code=$?" captures a non-zero exit without triggering set -e.
+  // "cmd || step_exit_code=$?" captures a non-zero exit without triggering set -e.
   const runDeploy = yamlPathInImage ? `
 # ── Deploy step (VM-native kubectl) ──
 # 1. Extract yaml from image without starting a container
-DEPLOY_CID=$(docker create '${esc(dockerImage)}')
-docker cp "$DEPLOY_CID":'${esc(yamlPathInImage)}' /tmp/grpc_deployment.yaml
-docker rm "$DEPLOY_CID"
+create_exit_code=0
+DEPLOY_CID=$(docker create '${esc(dockerImage)}') || create_exit_code=$?
+if [ "$create_exit_code" -ne 0 ]; then
+  fatal_error docker_image_not_found
+fi
+cp_exit_code=0
+docker cp "$DEPLOY_CID":'${esc(yamlPathInImage)}' /tmp/grpc_deployment.yaml || cp_exit_code=$?
+docker rm "$DEPLOY_CID" || true
+if [ "$cp_exit_code" -ne 0 ]; then
+  fatal_error deploy_failed
+fi
 
 # 2. Fetch GKE credentials (gcloud pre-installed in the custom VM image)
 # gkeCluster / gkeZone are inlined at script-generation time by the Cloud Function
 # Explicitly set KUBECONFIG so both gcloud and kubectl use the same file,
 # regardless of which user/HOME the metadata script runner uses.
 export KUBECONFIG=/tmp/gke-kubeconfig
+credentials_exit_code=0
 gcloud container clusters get-credentials '${esc(gkeCluster)}' \
-  --region '${esc(gkeZone)}' --project '${esc(CONFIG.projectId)}'
+  --region '${esc(gkeZone)}' --project '${esc(CONFIG.projectId)}' || credentials_exit_code=$?
+if [ "$credentials_exit_code" -ne 0 ]; then
+  rm -f /tmp/gke-kubeconfig
+  rm -f /tmp/grpc_deployment.yaml
+  fatal_error deploy_failed
+fi
 
 # 3. Apply (capture exit code without aborting under set -e)
 deploy_exit_code=0
@@ -210,9 +240,7 @@ rm -f /tmp/gke-kubeconfig
 rm -f /tmp/grpc_deployment.yaml
 
 if [ "$deploy_exit_code" -ne 0 ]; then
-  echo "Model deployment failed with exit code $deploy_exit_code"
-else
-  echo "Model deployed successfully"
+  fatal_error deploy_failed
 fi
 ` : '';
 
@@ -221,13 +249,21 @@ fi
   // time — the esc() function ensures single-quote safety for shell injection.
   return `#!/bin/bash
 set -euo pipefail
-
+${fatalErrorFn}
 # Authenticate Docker to Artifact Registry (gcloud pre-installed in custom image)
 # Extract registry hostname from the image path (e.g. asia-northeast1-docker.pkg.dev)
 REGISTRY=$(echo '${esc(dockerImage)}' | cut -d/ -f1)
-gcloud auth configure-docker "$REGISTRY" --quiet
+auth_exit_code=0
+gcloud auth configure-docker "$REGISTRY" --quiet || auth_exit_code=$?
+if [ "$auth_exit_code" -ne 0 ]; then
+  fatal_error registry_auth_failed
+fi
 
-docker pull '${esc(dockerImage)}'
+pull_exit_code=0
+docker pull '${esc(dockerImage)}' || pull_exit_code=$?
+if [ "$pull_exit_code" -ne 0 ]; then
+  fatal_error docker_image_not_found
+fi
 ${runPipeline}
 ${runDeploy}
 # ── Notify next step and self-delete ──
@@ -359,9 +395,52 @@ function buildVmConfig({ current, vmName, startupScript, zone, serviceAccount })
 
 // ─── Zone Fallback ────────────────────────────────────────────────────────────
 
+function errorText(err) {
+  return typeof err === 'string' ? err : JSON.stringify(err.message || err);
+}
+
 function isExhaustedError(err) {
-  const msg = typeof err === 'string' ? err : JSON.stringify(err.message || err);
-  return EXHAUSTED_CODES.some(code => msg.includes(code));
+  return EXHAUSTED_CODES.some(code => errorText(err).includes(code));
+}
+
+/**
+ * True when VM creation cannot succeed by switching zones or redelivering Pub/Sub
+ * (e.g. custom source image missing from the project).
+ */
+function isFatalVmError(err) {
+  const msg = errorText(err);
+  if (isExhaustedError(err)) return false;
+  if (/global\/images\//i.test(msg) && /not found|NOT_FOUND/i.test(msg)) return true;
+  if (!FATAL_VM_ERROR_CODES.some(code => msg.includes(code))) return false;
+  // NOT_FOUND for a zone-local accelerator is zone exhaustion, not fatal
+  if (msg.includes('acceleratorTypes')) return false;
+  return /global\/images\//i.test(msg) || /sourceImage|source image/i.test(msg);
+}
+
+/**
+ * Publish a terminal error so the pipeline stops and Pub/Sub does not keep
+ * redelivering the same task queue (matches startup-script error handling).
+ */
+async function publishPipelineError(authClient, err, forcedExitCode = null) {
+  const exitCode = forcedExitCode || (isFatalVmError(err) ? 'vm_image_not_found' : 'vm_create_failed');
+  const payload = JSON.stringify({
+    error:     true,
+    exit_code: exitCode,
+    detail:    String(err?.message || err).slice(0, 500),
+  });
+
+  try {
+    const pubsub = google.pubsub({ version: 'v1', auth: authClient });
+    await pubsub.projects.topics.publish({
+      topic: `projects/${CONFIG.projectId}/topics/${CONFIG.topicName}`,
+      requestBody: {
+        messages: [{ data: Buffer.from(payload).toString('base64') }],
+      },
+    });
+    console.log(`Published pipeline error to ${CONFIG.topicName}: ${payload}`);
+  } catch (pubErr) {
+    console.error(`Failed to publish pipeline error: ${pubErr.message}`);
+  }
 }
 
 /**
@@ -403,18 +482,24 @@ async function createVMWithFallback(authClient, configFactory) {
       }
 
       if (operation.error) {
-        const code = operation.error.errors?.[0]?.code || '';
-        if (EXHAUSTED_CODES.some(c => code.includes(c))) {
+        const opErr = JSON.stringify(operation.error);
+        if (isFatalVmError(opErr)) {
+          throw new Error(`Fatal VM error (non-retryable): ${opErr}`);
+        }
+        if (isExhaustedError(opErr)) {
           console.warn(`Zone ${z} exhausted (operation error), trying next...`);
           continue;
         }
-        throw new Error(`VM operation failed: ${JSON.stringify(operation.error)}`);
+        throw new Error(`VM operation failed: ${opErr}`);
       }
 
       console.log(`VM created in zone: ${z}, name: ${zonedConfig.name}`);
       return z;
 
     } catch (err) {
+      if (isFatalVmError(err)) {
+        throw err;
+      }
       if (isExhaustedError(err)) {
         console.warn(`Zone ${z} exhausted, trying next...`);
         continue;
@@ -431,6 +516,15 @@ async function createVMWithFallback(authClient, configFactory) {
 functions.cloudEvent('cronjobProcessPubSub', async cloudEvent => {
   const message = Buffer.from(cloudEvent.data.message.data, 'base64').toString().trim();
   console.log(`Received message: ${message}`);
+  let authClient;
+  const getAuthClient = async () => {
+    if (authClient) return authClient;
+    const auth = new google.auth.GoogleAuth({
+      scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+    });
+    authClient = await auth.getClient();
+    return authClient;
+  };
 
   // Terminal message checks
   if (message.startsWith('Exit code:')) {
@@ -446,14 +540,21 @@ functions.cloudEvent('cronjobProcessPubSub', async cloudEvent => {
   let cronjobInfo;
   try {
     cronjobInfo = JSON.parse(message);
-  } catch {
+  } catch (err) {
     console.error(`Invalid JSON message: ${message}`);
+    try {
+      const client = await getAuthClient();
+      await publishPipelineError(client, err, 'task_invalid');
+    } catch (publishErr) {
+      console.error(`Failed to publish validation error: ${publishErr.message}`);
+    }
     return;
   }
 
-  // Error payload
+  // Error payload (from VM startup script or Cloud Function after VM create failure)
   if (cronjobInfo?.error) {
-    console.error(`Pipeline step failed with exit code: ${cronjobInfo.exit_code}`);
+    const detail = cronjobInfo.detail ? `, detail: ${cronjobInfo.detail}` : '';
+    console.error(`Pipeline step failed with exit code: ${cronjobInfo.exit_code}${detail}`);
     return;
   }
 
@@ -470,6 +571,12 @@ functions.cloudEvent('cronjobProcessPubSub', async cloudEvent => {
     validateTask(current);
   } catch (err) {
     console.error(`Task validation failed: ${err.message}`);
+    try {
+      const client = await getAuthClient();
+      await publishPipelineError(client, err, 'task_invalid');
+    } catch (publishErr) {
+      console.error(`Failed to publish validation error: ${publishErr.message}`);
+    }
     return;
   }
 
@@ -513,10 +620,7 @@ functions.cloudEvent('cronjobProcessPubSub', async cloudEvent => {
 
   // Create VM
   try {
-    const auth = new google.auth.GoogleAuth({
-      scopes: ['https://www.googleapis.com/auth/cloud-platform'],
-    });
-    const authClient = await auth.getClient();
+    authClient = await getAuthClient();
 
     await createVMWithFallback(
       authClient,
@@ -525,5 +629,10 @@ functions.cloudEvent('cronjobProcessPubSub', async cloudEvent => {
 
   } catch (err) {
     console.error('Failed to create VM in all zones:', err);
+    // Ack the current message by returning, but publish a terminal error first so
+    // (1) the pipeline does not appear stuck and (2) redelivery does not spawn more VMs.
+    if (authClient) {
+      await publishPipelineError(authClient, err);
+    }
   }
 });

--- a/src/aigear/infrastructure/gcp/function/index.js
+++ b/src/aigear/infrastructure/gcp/function/index.js
@@ -548,7 +548,7 @@ async function createVMWithFallback(authClient, configFactory, vmName) {
 
   const existingZone = await findExistingVmZone(compute, vmName);
   if (existingZone) {
-    console.log(`VM ${vmName} already exists in zone ${existingZone}, skipping insert (Pub/Sub redelivery).`);
+    console.log(`VM ${vmName} already exists in zone ${existingZone}, skipping insert.`);
     return existingZone;
   }
 

--- a/src/aigear/infrastructure/gcp/function/index.js
+++ b/src/aigear/infrastructure/gcp/function/index.js
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto';
 import { google } from 'googleapis';
 import functions from '@google-cloud/functions-framework';
 
@@ -64,7 +65,17 @@ const FATAL_VM_ERROR_CODES = [
 
 // ─── Utilities ────────────────────────────────────────────────────────────────
 
+const INSERT_OPERATION_WAIT_MS = 20000;
+
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * Stable id for the current Pub/Sub payload so redeliveries reuse the same VM name
+ * instead of spawning duplicates with Date.now().
+ */
+function taskKeyFromMessage(message) {
+  return crypto.createHash('sha256').update(message).digest('hex').slice(0, 12);
+}
 
 /**
  * Converts a Python import path to the absolute yaml path inside the container.
@@ -403,6 +414,36 @@ function isExhaustedError(err) {
   return EXHAUSTED_CODES.some(code => errorText(err).includes(code));
 }
 
+function isAlreadyExistsError(err) {
+  const msg = errorText(err);
+  return msg.includes('alreadyExists') || msg.includes('ALREADY_EXISTS');
+}
+
+async function vmExistsInZone(compute, zone, vmName) {
+  try {
+    await compute.instances.get({
+      project:  CONFIG.projectId,
+      zone,
+      instance: vmName,
+    });
+    return true;
+  } catch (err) {
+    const msg = errorText(err);
+    if (msg.includes('NOT_FOUND') || msg.includes('404')) return false;
+    throw err;
+  }
+}
+
+/**
+ * Return the zone where a VM with this name already exists, or null.
+ */
+async function findExistingVmZone(compute, vmName) {
+  for (const z of CONFIG.fallbackZones) {
+    if (await vmExistsInZone(compute, z, vmName)) return z;
+  }
+  return null;
+}
+
 /**
  * True when VM creation cannot succeed by switching zones or redelivering Pub/Sub
  * (e.g. custom source image missing from the project).
@@ -444,17 +485,62 @@ async function publishPipelineError(authClient, err, forcedExitCode = null) {
 }
 
 /**
+ * Poll the insert operation briefly so fatal errors (e.g. missing custom image)
+ * are caught before acking Pub/Sub, without waiting for the full VM boot.
+ *
+ * @returns {{ exhausted?: true, pending?: true }}
+ */
+async function waitForInsertOperation(compute, zone, operation) {
+  const deadline = Date.now() + INSERT_OPERATION_WAIT_MS;
+
+  while (operation.status !== 'DONE' && Date.now() < deadline) {
+    await sleep(2000);
+    const opRes = await compute.zoneOperations.get({
+      project:   CONFIG.projectId,
+      zone,
+      operation: operation.name,
+    });
+    operation = opRes.data;
+  }
+
+  if (operation.status === 'DONE' && operation.error) {
+    const opErr = JSON.stringify(operation.error);
+    if (isFatalVmError(opErr)) {
+      throw new Error(`Fatal VM error (non-retryable): ${opErr}`);
+    }
+    if (isExhaustedError(opErr)) {
+      return { exhausted: true };
+    }
+    throw new Error(`VM operation failed: ${opErr}`);
+  }
+
+  if (operation.status !== 'DONE') {
+    console.log(`VM insert still running in zone ${zone}, acking Pub/Sub early.`);
+    return { pending: true };
+  }
+
+  return {};
+}
+
+/**
  * Tries each fallback zone in order until the VM is created.
  * serviceAccount is resolved once before the loop to avoid redundant metadata calls.
  *
  * @param {object}   authClient
  * @param {Function} configFactory  (zone, serviceAccount) => vmConfig
+ * @param {string}   vmName
  * @returns {Promise<string>}  the zone where the VM was successfully created
  */
-async function createVMWithFallback(authClient, configFactory) {
+async function createVMWithFallback(authClient, configFactory, vmName) {
   const compute        = google.compute({ version: 'v1', auth: authClient });
   const serviceAccount = await getRuntimeServiceAccount();
   console.log(`Using service account: ${serviceAccount}`);
+
+  const existingZone = await findExistingVmZone(compute, vmName);
+  if (existingZone) {
+    console.log(`VM ${vmName} already exists in zone ${existingZone}, skipping insert (Pub/Sub redelivery).`);
+    return existingZone;
+  }
 
   for (const z of CONFIG.fallbackZones) {
     console.log(`Trying zone: ${z}`);
@@ -467,36 +553,23 @@ async function createVMWithFallback(authClient, configFactory) {
         requestBody: zonedConfig,
       });
 
-      let operation = response.data;
-      console.log(`VM creation started in zone ${z}, operation: ${operation.name}`);
-
-      while (operation.status !== 'DONE') {
-        await sleep(3000);
-        const opRes = await compute.zoneOperations.get({
-          project:   CONFIG.projectId,
-          zone:      z,
-          operation: operation.name,
-        });
-        operation = opRes.data;
-        console.log(`Operation status: ${operation.status}`);
+      const operation = response.data;
+      const waitResult = await waitForInsertOperation(compute, z, operation);
+      if (waitResult.exhausted) {
+        console.warn(`Zone ${z} exhausted (operation error), trying next...`);
+        continue;
       }
 
-      if (operation.error) {
-        const opErr = JSON.stringify(operation.error);
-        if (isFatalVmError(opErr)) {
-          throw new Error(`Fatal VM error (non-retryable): ${opErr}`);
-        }
-        if (isExhaustedError(opErr)) {
-          console.warn(`Zone ${z} exhausted (operation error), trying next...`);
-          continue;
-        }
-        throw new Error(`VM operation failed: ${opErr}`);
-      }
-
-      console.log(`VM created in zone: ${z}, name: ${zonedConfig.name}`);
+      console.log(
+        `VM creation ${waitResult.pending ? 'started' : 'completed'} in zone ${z}, name: ${zonedConfig.name}, operation: ${operation.name}`,
+      );
       return z;
 
     } catch (err) {
+      if (isAlreadyExistsError(err)) {
+        console.log(`VM ${zonedConfig.name} already exists in zone ${z}, treating as success.`);
+        return z;
+      }
       if (isFatalVmError(err)) {
         throw err;
       }
@@ -590,6 +663,12 @@ functions.cloudEvent('cronjobProcessPubSub', async cloudEvent => {
     pipelineCommand = buildPipelineCommand(current);
   } catch (err) {
     console.error(`Failed to build pipeline command: ${err.message}`);
+    try {
+      const client = await getAuthClient();
+      await publishPipelineError(client, err, 'task_invalid');
+    } catch (publishErr) {
+      console.error(`Failed to publish validation error: ${publishErr.message}`);
+    }
     return;
   }
 
@@ -616,7 +695,7 @@ functions.cloudEvent('cronjobProcessPubSub', async cloudEvent => {
     gkeZone:        current.gke_zone    || '',
   });
 
-  const vmName = `${current.vm_name}-${Date.now()}`;
+  const vmName = `${current.vm_name}-${taskKeyFromMessage(message)}`;
 
   // Create VM
   try {
@@ -625,6 +704,7 @@ functions.cloudEvent('cronjobProcessPubSub', async cloudEvent => {
     await createVMWithFallback(
       authClient,
       (zone, serviceAccount) => buildVmConfig({ current, vmName, startupScript, zone, serviceAccount }),
+      vmName,
     );
 
   } catch (err) {

--- a/src/aigear/infrastructure/gcp/function/index.js
+++ b/src/aigear/infrastructure/gcp/function/index.js
@@ -419,6 +419,17 @@ function isAlreadyExistsError(err) {
   return msg.includes('alreadyExists') || msg.includes('ALREADY_EXISTS');
 }
 
+function isNotFoundError(err) {
+  const status = err?.response?.status ?? err?.code;
+  if (status === 404) return true;
+  const reasons = err?.response?.data?.error?.errors;
+  if (Array.isArray(reasons) && reasons.some(e => e.reason === 'notFound')) {
+    return true;
+  }
+  const msg = errorText(err);
+  return /not.?found/i.test(msg) || msg.includes('NOT_FOUND');
+}
+
 async function vmExistsInZone(compute, zone, vmName) {
   try {
     await compute.instances.get({
@@ -428,8 +439,7 @@ async function vmExistsInZone(compute, zone, vmName) {
     });
     return true;
   } catch (err) {
-    const msg = errorText(err);
-    if (msg.includes('NOT_FOUND') || msg.includes('404')) return false;
+    if (isNotFoundError(err)) return false;
     throw err;
   }
 }

--- a/src/aigear/infrastructure/gcp/infra.py
+++ b/src/aigear/infrastructure/gcp/infra.py
@@ -10,6 +10,7 @@ from aigear.infrastructure.gcp.artifacts import Artifacts
 from aigear.infrastructure.gcp.bucket import Bucket
 from aigear.infrastructure.gcp.build import CloudBuild
 from aigear.infrastructure.gcp.constant import entry_point_of_cloud_fuction
+from aigear.infrastructure.gcp.eventarc import EventarcTrigger
 from aigear.infrastructure.gcp.function import CloudFunction
 from aigear.infrastructure.gcp.iam import ServiceAccounts
 from aigear.infrastructure.gcp.kms import CloudKMS
@@ -93,6 +94,14 @@ class Infra:
         self.pubsub = PubSub(
             topic_name=self.aigear_config.gcp.pub_sub.topic_name,
             project_id=self.project_id,
+        )
+
+        self.eventarc_trigger = EventarcTrigger.from_function(
+            function_name=self.aigear_config.gcp.cloud_function.function_name,
+            region=self.location,
+            topic_name=self.aigear_config.gcp.pub_sub.topic_name,
+            project_id=self.project_id,
+            trigger_service_account=self.service_account,
         )
 
         self.artifacts = Artifacts(
@@ -341,6 +350,13 @@ class Infra:
         else:
             self._step_skip(f"Kubernetes Cluster ({cfg.kubernetes.cluster_name})")
 
+        if cfg.cloud_function.on:
+            phase2_tasks[f"Cloud Function ({cfg.cloud_function.function_name})"] = (
+                self._ensure_cloud_function
+            )
+        else:
+            self._step_skip(f"Cloud Function ({cfg.cloud_function.function_name})")
+
         if phase2_tasks:
             with ThreadPoolExecutor(max_workers=len(phase2_tasks)) as executor:
                 futures = {
@@ -352,34 +368,47 @@ class Infra:
                     if not future.result():
                         failed_steps.append(title)
 
-        # ── Gate 2→3: Pub/Sub must exist ──────────────────────────────
-        # Phase 2 already verified pubsub state; reuse that result instead of
-        # calling describe() again.
+        # ── Gate 2→3: Pub/Sub + Cloud Function must exist for Eventarc ─
         pubsub_step_key = f"Pub/Sub Topic ({cfg.pub_sub.topic_name})"
+        cf_step_key = f"Cloud Function ({cfg.cloud_function.function_name})"
         pubsub_ok = cfg.pub_sub.on and pubsub_step_key not in failed_steps
-        if cfg.cloud_function.on and not pubsub_ok:
-            self._step_fail(
-                f"Gate 2→3: Pub/Sub Topic ({cfg.pub_sub.topic_name})",
-                "not found — Phase 3 skipped",
-            )
-            failed_steps.append(
-                f"Gate 2→3: Pub/Sub Topic ({cfg.pub_sub.topic_name}) not found"
-            )
-            self._log_summary(failed_steps, "Init")
-            return
+        cf_ok = cfg.cloud_function.on and cf_step_key not in failed_steps
+        need_eventarc = cfg.pub_sub.on and cfg.cloud_function.on
 
-        # ── Phase 3: Cloud Function ────────────────────────────────────
-        if cfg.cloud_function.on:
-            success = self._step(
-                f"Cloud Function ({cfg.cloud_function.function_name})",
-                self._ensure_cloud_function,
-            )
-            if not success:
-                failed_steps.append(
-                    f"Cloud Function ({cfg.cloud_function.function_name})"
+        if need_eventarc:
+            if not pubsub_ok:
+                self._step_fail(
+                    f"Gate 2→3: Pub/Sub Topic ({cfg.pub_sub.topic_name})",
+                    "not found — Eventarc trigger skipped",
                 )
-        else:
-            self._step_skip(f"Cloud Function ({cfg.cloud_function.function_name})")
+                failed_steps.append(
+                    f"Gate 2→3: Pub/Sub Topic ({cfg.pub_sub.topic_name}) not found"
+                )
+                self._log_summary(failed_steps, "Init")
+                return
+            if not cf_ok:
+                self._step_fail(
+                    f"Gate 2→3: Cloud Function ({cfg.cloud_function.function_name})",
+                    "not found — Eventarc trigger skipped",
+                )
+                failed_steps.append(
+                    f"Gate 2→3: Cloud Function ({cfg.cloud_function.function_name}) not found"
+                )
+                self._log_summary(failed_steps, "Init")
+                return
+
+        # ── Phase 3: Eventarc Pub/Sub trigger ─────────────────────────
+        if need_eventarc:
+            trigger_label = (
+                f"Eventarc Trigger ({self.eventarc_trigger.trigger_name})"
+            )
+            success = self._step(trigger_label, self._ensure_eventarc_trigger)
+            if not success:
+                failed_steps.append(trigger_label)
+        elif cfg.cloud_function.on or cfg.pub_sub.on:
+            self._step_skip(
+                f"Eventarc Trigger ({self.eventarc_trigger.trigger_name})"
+            )
 
         self._log_summary(failed_steps, "Init")
 
@@ -554,9 +583,10 @@ class Infra:
 
     def _ensure_cloud_function(self):
         exists = self.cloud_function.describe()
+        function_name = self.aigear_config.gcp.cloud_function.function_name
         if not exists:
             logger.info(
-                f"Cloud Function ({self.aigear_config.gcp.cloud_function.function_name}) not found in region "
+                f"Cloud Function ({function_name}) not found in region "
                 f"({self.location}). Deploying Cloud Function..."
             )
             self.cloud_function.deploy()
@@ -564,13 +594,41 @@ class Infra:
                 sa_email=self.service_accounts.sa_email
             )
             logger.info(
-                f"Cloud Function ({self.aigear_config.gcp.cloud_function.function_name}) deployed successfully."
+                f"Cloud Function ({function_name}) deployed successfully."
             )
         else:
             logger.info(
-                f"Cloud Function ({self.aigear_config.gcp.cloud_function.function_name}) already exists in region "
+                f"Cloud Function ({function_name}) already exists in region "
                 f"({self.location}). Skipping deployment."
             )
+
+    def _ensure_eventarc_trigger(self):
+        trigger_name = self.eventarc_trigger.trigger_name
+        topic_name = self.aigear_config.gcp.pub_sub.topic_name
+        if not self.eventarc_trigger.describe():
+            logger.info(
+                f"Eventarc trigger ({trigger_name}) not found in region "
+                f"({self.location}). Creating Pub/Sub trigger..."
+            )
+            self.eventarc_trigger.add_permissions(
+                sa_email=self.service_accounts.sa_email
+            )
+            self.eventarc_trigger.create()
+        else:
+            logger.info(
+                f"Eventarc trigger ({trigger_name}) already exists in region "
+                f"({self.location}). Skipping creation."
+            )
+
+        if not self.pubsub.has_subscriptions():
+            raise RuntimeError(
+                f"Eventarc trigger ({trigger_name}) is configured but Pub/Sub topic "
+                f"({topic_name}) has no subscription. "
+                f"Verify Eventarc API is enabled in project ({self.project_id})."
+            )
+        logger.info(
+            f"Eventarc trigger ({trigger_name}) ready for topic ({topic_name})."
+        )
 
     def _ensure_pre_vm_image(self):
         from aigear.infrastructure.gcp.pre_vm_image import PreVMImage
@@ -731,11 +789,19 @@ class Infra:
                     if not future.result():
                         failed_steps.append(title)
 
-        # ── Phase 3: Cloud Function ────────────────────────────────────
         if cfg.cloud_function.on:
             self._step_no_update(f"Cloud Function ({cfg.cloud_function.function_name})")
         else:
             self._step_skip(f"Cloud Function ({cfg.cloud_function.function_name})")
+
+        if cfg.pub_sub.on and cfg.cloud_function.on:
+            self._step_no_update(
+                f"Eventarc Trigger ({self.eventarc_trigger.trigger_name})"
+            )
+        else:
+            self._step_skip(
+                f"Eventarc Trigger ({self.eventarc_trigger.trigger_name})"
+            )
 
         self._log_summary(failed_steps, "Update")
 
@@ -752,18 +818,18 @@ class Infra:
         failed_steps = []
         cfg = self.aigear_config.gcp
 
-        # ── Phase 1: Cloud Function (reverse of creation phase 3) ────
-        if cfg.cloud_function.on:
-            success = self._step(
-                f"Cloud Function ({cfg.cloud_function.function_name})",
-                self._delete_cloud_function,
+        # ── Phase 1: Eventarc trigger (reverse of creation phase 3) ───
+        if cfg.pub_sub.on and cfg.cloud_function.on:
+            trigger_label = (
+                f"Eventarc Trigger ({self.eventarc_trigger.trigger_name})"
             )
+            success = self._step(trigger_label, self._delete_eventarc_trigger)
             if not success:
-                failed_steps.append(
-                    f"Cloud Function ({cfg.cloud_function.function_name})"
-                )
+                failed_steps.append(trigger_label)
         else:
-            self._step_skip(f"Cloud Function ({cfg.cloud_function.function_name})")
+            self._step_skip(
+                f"Eventarc Trigger ({self.eventarc_trigger.trigger_name})"
+            )
 
         # ── Phase 2: Independent resources (parallel) ─────────────────
         phase2_tasks = {}
@@ -821,6 +887,13 @@ class Infra:
         else:
             self._step_skip(f"Kubernetes Cluster ({cfg.kubernetes.cluster_name})")
 
+        if cfg.cloud_function.on:
+            phase2_tasks[f"Cloud Function ({cfg.cloud_function.function_name})"] = (
+                self._delete_cloud_function
+            )
+        else:
+            self._step_skip(f"Cloud Function ({cfg.cloud_function.function_name})")
+
         if phase2_tasks:
             with ThreadPoolExecutor(max_workers=len(phase2_tasks)) as executor:
                 futures = {
@@ -848,6 +921,17 @@ class Infra:
     # ================================================================
     # Actual delete actions
     # ================================================================
+    def _delete_eventarc_trigger(self):
+        if self.eventarc_trigger.describe():
+            logger.info(
+                f"Deleting Eventarc trigger ({self.eventarc_trigger.trigger_name})..."
+            )
+            self.eventarc_trigger.delete()
+        else:
+            logger.info(
+                f"Eventarc trigger ({self.eventarc_trigger.trigger_name}) not found. Skipping."
+            )
+
     def _delete_cloud_function(self):
         exists = self.cloud_function.describe()
         if exists:
@@ -1047,6 +1131,11 @@ class Infra:
                 f"Cloud Function ({cfg.cloud_function.function_name})",
                 cfg.cloud_function.on,
                 self.cloud_function.describe,
+            ),
+            (
+                f"Eventarc Trigger ({self.eventarc_trigger.trigger_name})",
+                cfg.pub_sub.on and cfg.cloud_function.on,
+                self.eventarc_trigger.describe,
             ),
         ]
 

--- a/src/aigear/infrastructure/gcp/infra.py
+++ b/src/aigear/infrastructure/gcp/infra.py
@@ -244,6 +244,49 @@ class Infra:
         logger.error(f"❌ {title} FAILED ({reason})")
         logger.info("---------------------------------------------------")
 
+    @staticmethod
+    def _needs_eventarc(cfg) -> bool:
+        return cfg.pub_sub.on and cfg.cloud_function.on
+
+    def _eventarc_title(self) -> str:
+        return f"Eventarc Pub/Sub Trigger ({self.eventarc_trigger.trigger_name})"
+
+    def _phase2_add(self, tasks: dict, enabled: bool, title: str, fn):
+        if enabled:
+            tasks[title] = fn
+        else:
+            self._step_skip(title)
+
+    def _run_parallel(self, tasks: dict, failed_steps: list):
+        if not tasks:
+            return
+        with ThreadPoolExecutor(max_workers=len(tasks)) as executor:
+            futures = {
+                executor.submit(self._step, title, fn): title
+                for title, fn in tasks.items()
+            }
+            for future in as_completed(futures):
+                title = futures[future]
+                if not future.result():
+                    failed_steps.append(title)
+
+    def _gate_eventarc_ready(self, cfg, failed_steps: list) -> bool:
+        if not self._needs_eventarc(cfg):
+            return True
+        required = (
+            f"Pub/Sub Topic ({cfg.pub_sub.topic_name})",
+            f"Cloud Function ({cfg.cloud_function.function_name})",
+        )
+        missing = [title for title in required if title in failed_steps]
+        if not missing:
+            return True
+        self._step_fail(
+            "Gate 2→3: Eventarc Pub/Sub Trigger",
+            f"prerequisites missing ({', '.join(missing)}) — Phase 3 skipped",
+        )
+        failed_steps.append("Gate 2→3: Eventarc Pub/Sub Trigger prerequisites missing")
+        return False
+
     def _log_summary(self, failed_steps, title):
         logger.info("===================================================")
         if failed_steps:
@@ -299,6 +342,8 @@ class Infra:
 
         # ── Phase 2: Independent resources (parallel) ─────────────────
         phase2_tasks = {}
+        cf_title = f"Cloud Function ({cfg.cloud_function.function_name})"
+        sa_email = self.service_accounts.sa_email
 
         if cfg.bucket.on:
             phase2_tasks[f"Model Bucket ({cfg.bucket.bucket_name})"] = (
@@ -313,97 +358,57 @@ class Infra:
                 f"Release Model Bucket ({cfg.bucket.bucket_name_for_release})"
             )
 
-        if cfg.artifacts.on:
-            phase2_tasks[f"Artifact Registry ({cfg.artifacts.repository_name})"] = (
-                self._ensure_artifacts
-            )
-        else:
-            self._step_skip(f"Artifact Registry ({cfg.artifacts.repository_name})")
+        self._phase2_add(
+            phase2_tasks,
+            cfg.artifacts.on,
+            f"Artifact Registry ({cfg.artifacts.repository_name})",
+            self._ensure_artifacts,
+        )
+        self._phase2_add(
+            phase2_tasks,
+            cfg.pub_sub.on,
+            f"Pub/Sub Topic ({cfg.pub_sub.topic_name})",
+            self._ensure_pubsub,
+        )
+        self._phase2_add(
+            phase2_tasks,
+            cfg.kms.on,
+            f"Cloud KMS ({cfg.kms.keyring_name}/{cfg.kms.key_name})",
+            self._ensure_kms,
+        )
+        self._phase2_add(
+            phase2_tasks,
+            cfg.cloud_build.on,
+            f"Cloud Build Trigger ({cfg.cloud_build.trigger_name})",
+            self._ensure_cloud_build,
+        )
+        self._phase2_add(
+            phase2_tasks, cfg.pre_vm_image.on, "Pre-VM Image (pre_vm_image)", self._ensure_pre_vm_image
+        )
+        self._phase2_add(
+            phase2_tasks,
+            cfg.kubernetes.on,
+            f"Kubernetes Cluster ({cfg.kubernetes.cluster_name})",
+            self._ensure_kubernetes_cluster,
+        )
+        self._phase2_add(
+            phase2_tasks,
+            cfg.cloud_function.on,
+            cf_title,
+            lambda: self.cloud_function.ensure(sa_email),
+        )
+        self._run_parallel(phase2_tasks, failed_steps)
 
-        if cfg.pub_sub.on:
-            phase2_tasks[f"Pub/Sub Topic ({cfg.pub_sub.topic_name})"] = (
-                self._ensure_pubsub
-            )
-        else:
-            self._step_skip(f"Pub/Sub Topic ({cfg.pub_sub.topic_name})")
-
-        if cfg.kms.on:
-            phase2_tasks[f"Cloud KMS ({cfg.kms.keyring_name}/{cfg.kms.key_name})"] = (
-                self._ensure_kms
-            )
-        else:
-            self._step_skip(f"Cloud KMS ({cfg.kms.keyring_name}/{cfg.kms.key_name})")
-
-        if cfg.cloud_build.on:
-            phase2_tasks[f"Cloud Build Trigger ({cfg.cloud_build.trigger_name})"] = (
-                self._ensure_cloud_build
-            )
-        else:
-            self._step_skip(f"Cloud Build Trigger ({cfg.cloud_build.trigger_name})")
-
-        if cfg.pre_vm_image.on:
-            phase2_tasks["Pre-VM Image (pre_vm_image)"] = self._ensure_pre_vm_image
-        else:
-            self._step_skip("Pre-VM Image (pre_vm_image)")
-
-        if cfg.kubernetes.on:
-            phase2_tasks[f"Kubernetes Cluster ({cfg.kubernetes.cluster_name})"] = (
-                self._ensure_kubernetes_cluster
-            )
-        else:
-            self._step_skip(f"Kubernetes Cluster ({cfg.kubernetes.cluster_name})")
-
-        if cfg.cloud_function.on:
-            phase2_tasks[f"Cloud Function ({cfg.cloud_function.function_name})"] = (
-                self._ensure_cloud_function
-            )
-        else:
-            self._step_skip(f"Cloud Function ({cfg.cloud_function.function_name})")
-
-        if phase2_tasks:
-            with ThreadPoolExecutor(max_workers=len(phase2_tasks)) as executor:
-                futures = {
-                    executor.submit(self._step, title, fn): title
-                    for title, fn in phase2_tasks.items()
-                }
-                for future in as_completed(futures):
-                    title = futures[future]
-                    if not future.result():
-                        failed_steps.append(title)
-
-        # ── Gate 2→3: Pub/Sub Topic + Cloud Function before Eventarc ──
-        pubsub_step_key = f"Pub/Sub Topic ({cfg.pub_sub.topic_name})"
-        cf_step_key = f"Cloud Function ({cfg.cloud_function.function_name})"
-        pubsub_ok = cfg.pub_sub.on and pubsub_step_key not in failed_steps
-        cf_ok = cfg.cloud_function.on and cf_step_key not in failed_steps
-        need_eventarc = cfg.pub_sub.on and cfg.cloud_function.on
-
-        if need_eventarc and (not pubsub_ok or not cf_ok):
-            reasons = []
-            if not pubsub_ok:
-                reasons.append(f"Pub/Sub Topic ({cfg.pub_sub.topic_name})")
-            if not cf_ok:
-                reasons.append(f"Cloud Function ({cfg.cloud_function.function_name})")
-            self._step_fail(
-                "Gate 2→3: Eventarc Pub/Sub Trigger",
-                f"prerequisites missing ({', '.join(reasons)}) — Phase 3 skipped",
-            )
-            failed_steps.append(f"Gate 2→3: Eventarc Pub/Sub Trigger prerequisites missing")
-            self._log_summary(failed_steps, "Init")
-            return
-
-        # ── Phase 3: Eventarc Pub/Sub trigger (official two-step flow) ─
-        if need_eventarc:
-            trigger_label = (
-                f"Eventarc Pub/Sub Trigger ({self.eventarc_trigger.trigger_name})"
-            )
-            success = self._step(trigger_label, self._ensure_eventarc_trigger)
-            if not success:
-                failed_steps.append(trigger_label)
-        elif cfg.cloud_function.on or cfg.pub_sub.on:
-            self._step_skip(
-                f"Eventarc Pub/Sub Trigger ({self.eventarc_trigger.trigger_name})"
-            )
+        # ── Phase 3: Eventarc Pub/Sub trigger ─────────────────────────
+        if self._needs_eventarc(cfg):
+            if not self._gate_eventarc_ready(cfg, failed_steps):
+                self._log_summary(failed_steps, "Init")
+                return
+            title = self._eventarc_title()
+            if not self._step(title, self.eventarc_trigger.ensure):
+                failed_steps.append(title)
+        elif cfg.pub_sub.on or cfg.cloud_function.on:
+            self._step_skip(self._eventarc_title())
 
         self._log_summary(failed_steps, "Init")
 
@@ -576,47 +581,6 @@ class Infra:
             f"Cloud Build trigger ({self.aigear_config.gcp.cloud_build.trigger_name}) updated successfully."
         )
 
-    def _ensure_cloud_function(self):
-        exists = self.cloud_function.describe()
-        function_name = self.aigear_config.gcp.cloud_function.function_name
-        if not exists:
-            logger.info(
-                f"Cloud Function ({function_name}) not found in region "
-                f"({self.location}). Deploying Cloud Function (no Pub/Sub trigger)..."
-            )
-            self.cloud_function.deploy()
-            logger.info(f"Cloud Function ({function_name}) deployed successfully.")
-        else:
-            logger.info(
-                f"Cloud Function ({function_name}) already exists in region "
-                f"({self.location}). Skipping deployment."
-            )
-        self.cloud_function.add_permissions_to_cloud_function(
-            sa_email=self.service_accounts.sa_email
-        )
-
-    def _ensure_eventarc_trigger(self):
-        trigger = self.eventarc_trigger
-        topic_name = self.aigear_config.gcp.pub_sub.topic_name
-        if not trigger.describe():
-            logger.info(
-                f"Eventarc trigger ({trigger.trigger_name}) not found in location "
-                f"({trigger.location}). Creating Pub/Sub trigger..."
-            )
-            trigger.add_trigger_permissions()
-            trigger.create()
-            logger.info(f"Eventarc trigger ({trigger.trigger_name}) created successfully.")
-        else:
-            logger.info(
-                f"Eventarc trigger ({trigger.trigger_name}) already exists in location "
-                f"({trigger.location}). Skipping creation."
-            )
-        if not self.pubsub.has_subscriptions():
-            raise RuntimeError(
-                f"Eventarc trigger ({trigger.trigger_name}) exists but Pub/Sub topic "
-                f"({topic_name}) has no subscription."
-            )
-
     def _ensure_pre_vm_image(self):
         from aigear.infrastructure.gcp.pre_vm_image import PreVMImage
 
@@ -765,31 +729,17 @@ class Infra:
         else:
             self._step_skip("Pre-VM Image (pre_vm_image)")
 
-        if phase2_tasks:
-            with ThreadPoolExecutor(max_workers=len(phase2_tasks)) as executor:
-                futures = {
-                    executor.submit(self._step, title, fn): title
-                    for title, fn in phase2_tasks.items()
-                }
-                for future in as_completed(futures):
-                    title = futures[future]
-                    if not future.result():
-                        failed_steps.append(title)
+        self._run_parallel(phase2_tasks, failed_steps)
 
         if cfg.cloud_function.on:
             self._step_no_update(f"Cloud Function ({cfg.cloud_function.function_name})")
         else:
             self._step_skip(f"Cloud Function ({cfg.cloud_function.function_name})")
 
-        need_eventarc = cfg.pub_sub.on and cfg.cloud_function.on
-        if need_eventarc:
-            self._step_no_update(
-                f"Eventarc Pub/Sub Trigger ({self.eventarc_trigger.trigger_name})"
-            )
-        elif cfg.cloud_function.on or cfg.pub_sub.on:
-            self._step_skip(
-                f"Eventarc Pub/Sub Trigger ({self.eventarc_trigger.trigger_name})"
-            )
+        if self._needs_eventarc(cfg):
+            self._step_no_update(self._eventarc_title())
+        elif cfg.pub_sub.on or cfg.cloud_function.on:
+            self._step_skip(self._eventarc_title())
 
         self._log_summary(failed_steps, "Update")
 
@@ -807,18 +757,12 @@ class Infra:
         cfg = self.aigear_config.gcp
 
         # ── Phase 1: Eventarc trigger, then Cloud Function ───────────
-        need_eventarc = cfg.pub_sub.on and cfg.cloud_function.on
-        if need_eventarc:
-            trigger_label = (
-                f"Eventarc Pub/Sub Trigger ({self.eventarc_trigger.trigger_name})"
-            )
-            success = self._step(trigger_label, self._delete_eventarc_trigger)
-            if not success:
-                failed_steps.append(trigger_label)
-        elif cfg.cloud_function.on or cfg.pub_sub.on:
-            self._step_skip(
-                f"Eventarc Pub/Sub Trigger ({self.eventarc_trigger.trigger_name})"
-            )
+        if self._needs_eventarc(cfg):
+            title = self._eventarc_title()
+            if not self._step(title, self.eventarc_trigger.delete_if_exists):
+                failed_steps.append(title)
+        elif cfg.pub_sub.on or cfg.cloud_function.on:
+            self._step_skip(self._eventarc_title())
 
         if cfg.cloud_function.on:
             success = self._step(
@@ -848,56 +792,40 @@ class Infra:
                 f"Release Model Bucket ({cfg.bucket.bucket_name_for_release})"
             )
 
-        if cfg.artifacts.on:
-            phase2_tasks[f"Artifact Registry ({cfg.artifacts.repository_name})"] = (
-                self._delete_artifacts
-            )
-        else:
-            self._step_skip(f"Artifact Registry ({cfg.artifacts.repository_name})")
-
-        if cfg.pub_sub.on:
-            phase2_tasks[f"Pub/Sub Topic ({cfg.pub_sub.topic_name})"] = (
-                self._delete_pubsub
-            )
-        else:
-            self._step_skip(f"Pub/Sub Topic ({cfg.pub_sub.topic_name})")
-
-        if cfg.kms.on:
-            phase2_tasks[f"Cloud KMS ({cfg.kms.keyring_name}/{cfg.kms.key_name})"] = (
-                self._delete_kms
-            )
-        else:
-            self._step_skip(f"Cloud KMS ({cfg.kms.keyring_name}/{cfg.kms.key_name})")
-
-        if cfg.cloud_build.on:
-            phase2_tasks[f"Cloud Build Trigger ({cfg.cloud_build.trigger_name})"] = (
-                self._delete_cloud_build
-            )
-        else:
-            self._step_skip(f"Cloud Build Trigger ({cfg.cloud_build.trigger_name})")
-
-        if cfg.pre_vm_image.on:
-            phase2_tasks["Pre-VM Image (pre_vm_image)"] = self._delete_pre_vm_image
-        else:
-            self._step_skip("Pre-VM Image (pre_vm_image)")
-
-        if cfg.kubernetes.on:
-            phase2_tasks[f"Kubernetes Cluster ({cfg.kubernetes.cluster_name})"] = (
-                self._delete_kubernetes_cluster
-            )
-        else:
-            self._step_skip(f"Kubernetes Cluster ({cfg.kubernetes.cluster_name})")
-
-        if phase2_tasks:
-            with ThreadPoolExecutor(max_workers=len(phase2_tasks)) as executor:
-                futures = {
-                    executor.submit(self._step, title, fn): title
-                    for title, fn in phase2_tasks.items()
-                }
-                for future in as_completed(futures):
-                    title = futures[future]
-                    if not future.result():
-                        failed_steps.append(title)
+        self._phase2_add(
+            phase2_tasks,
+            cfg.artifacts.on,
+            f"Artifact Registry ({cfg.artifacts.repository_name})",
+            self._delete_artifacts,
+        )
+        self._phase2_add(
+            phase2_tasks,
+            cfg.pub_sub.on,
+            f"Pub/Sub Topic ({cfg.pub_sub.topic_name})",
+            self._delete_pubsub,
+        )
+        self._phase2_add(
+            phase2_tasks,
+            cfg.kms.on,
+            f"Cloud KMS ({cfg.kms.keyring_name}/{cfg.kms.key_name})",
+            self._delete_kms,
+        )
+        self._phase2_add(
+            phase2_tasks,
+            cfg.cloud_build.on,
+            f"Cloud Build Trigger ({cfg.cloud_build.trigger_name})",
+            self._delete_cloud_build,
+        )
+        self._phase2_add(
+            phase2_tasks, cfg.pre_vm_image.on, "Pre-VM Image (pre_vm_image)", self._delete_pre_vm_image
+        )
+        self._phase2_add(
+            phase2_tasks,
+            cfg.kubernetes.on,
+            f"Kubernetes Cluster ({cfg.kubernetes.cluster_name})",
+            self._delete_kubernetes_cluster,
+        )
+        self._run_parallel(phase2_tasks, failed_steps)
 
         # ── Phase 3: Service Account (reverse of creation phase 1) ───
         if cfg.iam.on:
@@ -915,16 +843,6 @@ class Infra:
     # ================================================================
     # Actual delete actions
     # ================================================================
-    def _delete_eventarc_trigger(self):
-        trigger = self.eventarc_trigger
-        if trigger.describe():
-            logger.info(f"Deleting Eventarc trigger ({trigger.trigger_name})...")
-            trigger.delete()
-        else:
-            logger.info(
-                f"Eventarc trigger ({trigger.trigger_name}) not found. Skipping."
-            )
-
     def _delete_cloud_function(self):
         exists = self.cloud_function.describe()
         if exists:
@@ -1126,8 +1044,8 @@ class Infra:
                 self.cloud_function.describe,
             ),
             (
-                f"Eventarc Pub/Sub Trigger ({self.eventarc_trigger.trigger_name})",
-                cfg.pub_sub.on and cfg.cloud_function.on,
+                self._eventarc_title(),
+                self._needs_eventarc(cfg),
                 self.eventarc_trigger.describe,
             ),
         ]

--- a/src/aigear/infrastructure/gcp/infra.py
+++ b/src/aigear/infrastructure/gcp/infra.py
@@ -10,7 +10,7 @@ from aigear.infrastructure.gcp.artifacts import Artifacts
 from aigear.infrastructure.gcp.bucket import Bucket
 from aigear.infrastructure.gcp.build import CloudBuild
 from aigear.infrastructure.gcp.constant import entry_point_of_cloud_fuction
-from aigear.infrastructure.gcp.eventarc import EventarcTrigger
+from aigear.infrastructure.gcp.eventarc import EventarcPubSubTrigger, pubsub_trigger_name
 from aigear.infrastructure.gcp.function import CloudFunction
 from aigear.infrastructure.gcp.iam import ServiceAccounts
 from aigear.infrastructure.gcp.kms import CloudKMS
@@ -96,14 +96,6 @@ class Infra:
             project_id=self.project_id,
         )
 
-        self.eventarc_trigger = EventarcTrigger.from_function(
-            function_name=self.aigear_config.gcp.cloud_function.function_name,
-            region=self.location,
-            topic_name=self.aigear_config.gcp.pub_sub.topic_name,
-            project_id=self.project_id,
-            trigger_service_account=self.service_account,
-        )
-
         self.artifacts = Artifacts(
             repository_name=self.aigear_config.gcp.artifacts.repository_name,
             location=self.location,
@@ -124,6 +116,17 @@ class Infra:
             location=self.location,
             keyring_name=self.aigear_config.gcp.kms.keyring_name,
             key_name=self.aigear_config.gcp.kms.key_name,
+        )
+
+        function_name = self.aigear_config.gcp.cloud_function.function_name
+        self.eventarc_trigger = EventarcPubSubTrigger(
+            trigger_name=pubsub_trigger_name(function_name),
+            location=self.location,
+            project_id=self.project_id,
+            function_name=function_name,
+            function_region=self.location,
+            topic_name=self.aigear_config.gcp.pub_sub.topic_name,
+            trigger_service_account=self.service_account,
         )
 
     # ================================================================
@@ -368,46 +371,38 @@ class Infra:
                     if not future.result():
                         failed_steps.append(title)
 
-        # ── Gate 2→3: Pub/Sub + Cloud Function must exist for Eventarc ─
+        # ── Gate 2→3: Pub/Sub Topic + Cloud Function before Eventarc ──
         pubsub_step_key = f"Pub/Sub Topic ({cfg.pub_sub.topic_name})"
         cf_step_key = f"Cloud Function ({cfg.cloud_function.function_name})"
         pubsub_ok = cfg.pub_sub.on and pubsub_step_key not in failed_steps
         cf_ok = cfg.cloud_function.on and cf_step_key not in failed_steps
         need_eventarc = cfg.pub_sub.on and cfg.cloud_function.on
 
-        if need_eventarc:
+        if need_eventarc and (not pubsub_ok or not cf_ok):
+            reasons = []
             if not pubsub_ok:
-                self._step_fail(
-                    f"Gate 2→3: Pub/Sub Topic ({cfg.pub_sub.topic_name})",
-                    "not found — Eventarc trigger skipped",
-                )
-                failed_steps.append(
-                    f"Gate 2→3: Pub/Sub Topic ({cfg.pub_sub.topic_name}) not found"
-                )
-                self._log_summary(failed_steps, "Init")
-                return
+                reasons.append(f"Pub/Sub Topic ({cfg.pub_sub.topic_name})")
             if not cf_ok:
-                self._step_fail(
-                    f"Gate 2→3: Cloud Function ({cfg.cloud_function.function_name})",
-                    "not found — Eventarc trigger skipped",
-                )
-                failed_steps.append(
-                    f"Gate 2→3: Cloud Function ({cfg.cloud_function.function_name}) not found"
-                )
-                self._log_summary(failed_steps, "Init")
-                return
+                reasons.append(f"Cloud Function ({cfg.cloud_function.function_name})")
+            self._step_fail(
+                "Gate 2→3: Eventarc Pub/Sub Trigger",
+                f"prerequisites missing ({', '.join(reasons)}) — Phase 3 skipped",
+            )
+            failed_steps.append(f"Gate 2→3: Eventarc Pub/Sub Trigger prerequisites missing")
+            self._log_summary(failed_steps, "Init")
+            return
 
-        # ── Phase 3: Eventarc Pub/Sub trigger ─────────────────────────
+        # ── Phase 3: Eventarc Pub/Sub trigger (official two-step flow) ─
         if need_eventarc:
             trigger_label = (
-                f"Eventarc Trigger ({self.eventarc_trigger.trigger_name})"
+                f"Eventarc Pub/Sub Trigger ({self.eventarc_trigger.trigger_name})"
             )
             success = self._step(trigger_label, self._ensure_eventarc_trigger)
             if not success:
                 failed_steps.append(trigger_label)
         elif cfg.cloud_function.on or cfg.pub_sub.on:
             self._step_skip(
-                f"Eventarc Trigger ({self.eventarc_trigger.trigger_name})"
+                f"Eventarc Pub/Sub Trigger ({self.eventarc_trigger.trigger_name})"
             )
 
         self._log_summary(failed_steps, "Init")
@@ -587,48 +582,40 @@ class Infra:
         if not exists:
             logger.info(
                 f"Cloud Function ({function_name}) not found in region "
-                f"({self.location}). Deploying Cloud Function..."
+                f"({self.location}). Deploying Cloud Function (no Pub/Sub trigger)..."
             )
             self.cloud_function.deploy()
-            self.cloud_function.add_permissions_to_cloud_function(
-                sa_email=self.service_accounts.sa_email
-            )
-            logger.info(
-                f"Cloud Function ({function_name}) deployed successfully."
-            )
+            logger.info(f"Cloud Function ({function_name}) deployed successfully.")
         else:
             logger.info(
                 f"Cloud Function ({function_name}) already exists in region "
                 f"({self.location}). Skipping deployment."
             )
+        self.cloud_function.add_permissions_to_cloud_function(
+            sa_email=self.service_accounts.sa_email
+        )
 
     def _ensure_eventarc_trigger(self):
-        trigger_name = self.eventarc_trigger.trigger_name
+        trigger = self.eventarc_trigger
         topic_name = self.aigear_config.gcp.pub_sub.topic_name
-        if not self.eventarc_trigger.describe():
+        if not trigger.describe():
             logger.info(
-                f"Eventarc trigger ({trigger_name}) not found in region "
-                f"({self.location}). Creating Pub/Sub trigger..."
+                f"Eventarc trigger ({trigger.trigger_name}) not found in location "
+                f"({trigger.location}). Creating Pub/Sub trigger..."
             )
-            self.eventarc_trigger.add_permissions(
-                sa_email=self.service_accounts.sa_email
-            )
-            self.eventarc_trigger.create()
+            trigger.add_trigger_permissions()
+            trigger.create()
+            logger.info(f"Eventarc trigger ({trigger.trigger_name}) created successfully.")
         else:
             logger.info(
-                f"Eventarc trigger ({trigger_name}) already exists in region "
-                f"({self.location}). Skipping creation."
+                f"Eventarc trigger ({trigger.trigger_name}) already exists in location "
+                f"({trigger.location}). Skipping creation."
             )
-
         if not self.pubsub.has_subscriptions():
             raise RuntimeError(
-                f"Eventarc trigger ({trigger_name}) is configured but Pub/Sub topic "
-                f"({topic_name}) has no subscription. "
-                f"Verify Eventarc API is enabled in project ({self.project_id})."
+                f"Eventarc trigger ({trigger.trigger_name}) exists but Pub/Sub topic "
+                f"({topic_name}) has no subscription."
             )
-        logger.info(
-            f"Eventarc trigger ({trigger_name}) ready for topic ({topic_name})."
-        )
 
     def _ensure_pre_vm_image(self):
         from aigear.infrastructure.gcp.pre_vm_image import PreVMImage
@@ -794,13 +781,14 @@ class Infra:
         else:
             self._step_skip(f"Cloud Function ({cfg.cloud_function.function_name})")
 
-        if cfg.pub_sub.on and cfg.cloud_function.on:
+        need_eventarc = cfg.pub_sub.on and cfg.cloud_function.on
+        if need_eventarc:
             self._step_no_update(
-                f"Eventarc Trigger ({self.eventarc_trigger.trigger_name})"
+                f"Eventarc Pub/Sub Trigger ({self.eventarc_trigger.trigger_name})"
             )
-        else:
+        elif cfg.cloud_function.on or cfg.pub_sub.on:
             self._step_skip(
-                f"Eventarc Trigger ({self.eventarc_trigger.trigger_name})"
+                f"Eventarc Pub/Sub Trigger ({self.eventarc_trigger.trigger_name})"
             )
 
         self._log_summary(failed_steps, "Update")
@@ -818,18 +806,31 @@ class Infra:
         failed_steps = []
         cfg = self.aigear_config.gcp
 
-        # ── Phase 1: Eventarc trigger (reverse of creation phase 3) ───
-        if cfg.pub_sub.on and cfg.cloud_function.on:
+        # ── Phase 1: Eventarc trigger, then Cloud Function ───────────
+        need_eventarc = cfg.pub_sub.on and cfg.cloud_function.on
+        if need_eventarc:
             trigger_label = (
-                f"Eventarc Trigger ({self.eventarc_trigger.trigger_name})"
+                f"Eventarc Pub/Sub Trigger ({self.eventarc_trigger.trigger_name})"
             )
             success = self._step(trigger_label, self._delete_eventarc_trigger)
             if not success:
                 failed_steps.append(trigger_label)
-        else:
+        elif cfg.cloud_function.on or cfg.pub_sub.on:
             self._step_skip(
-                f"Eventarc Trigger ({self.eventarc_trigger.trigger_name})"
+                f"Eventarc Pub/Sub Trigger ({self.eventarc_trigger.trigger_name})"
             )
+
+        if cfg.cloud_function.on:
+            success = self._step(
+                f"Cloud Function ({cfg.cloud_function.function_name})",
+                self._delete_cloud_function,
+            )
+            if not success:
+                failed_steps.append(
+                    f"Cloud Function ({cfg.cloud_function.function_name})"
+                )
+        else:
+            self._step_skip(f"Cloud Function ({cfg.cloud_function.function_name})")
 
         # ── Phase 2: Independent resources (parallel) ─────────────────
         phase2_tasks = {}
@@ -887,13 +888,6 @@ class Infra:
         else:
             self._step_skip(f"Kubernetes Cluster ({cfg.kubernetes.cluster_name})")
 
-        if cfg.cloud_function.on:
-            phase2_tasks[f"Cloud Function ({cfg.cloud_function.function_name})"] = (
-                self._delete_cloud_function
-            )
-        else:
-            self._step_skip(f"Cloud Function ({cfg.cloud_function.function_name})")
-
         if phase2_tasks:
             with ThreadPoolExecutor(max_workers=len(phase2_tasks)) as executor:
                 futures = {
@@ -922,14 +916,13 @@ class Infra:
     # Actual delete actions
     # ================================================================
     def _delete_eventarc_trigger(self):
-        if self.eventarc_trigger.describe():
-            logger.info(
-                f"Deleting Eventarc trigger ({self.eventarc_trigger.trigger_name})..."
-            )
-            self.eventarc_trigger.delete()
+        trigger = self.eventarc_trigger
+        if trigger.describe():
+            logger.info(f"Deleting Eventarc trigger ({trigger.trigger_name})...")
+            trigger.delete()
         else:
             logger.info(
-                f"Eventarc trigger ({self.eventarc_trigger.trigger_name}) not found. Skipping."
+                f"Eventarc trigger ({trigger.trigger_name}) not found. Skipping."
             )
 
     def _delete_cloud_function(self):
@@ -1133,7 +1126,7 @@ class Infra:
                 self.cloud_function.describe,
             ),
             (
-                f"Eventarc Trigger ({self.eventarc_trigger.trigger_name})",
+                f"Eventarc Pub/Sub Trigger ({self.eventarc_trigger.trigger_name})",
                 cfg.pub_sub.on and cfg.cloud_function.on,
                 self.eventarc_trigger.describe,
             ),

--- a/src/aigear/infrastructure/gcp/pub_sub.py
+++ b/src/aigear/infrastructure/gcp/pub_sub.py
@@ -1,7 +1,6 @@
 from aigear.common import run_sh
 from aigear.common.logger import Logging
 
-
 logger = Logging(log_name=__name__).console_logging()
 
 
@@ -83,7 +82,14 @@ class PubSub:
     def _delete_subscriptions(self):
         for sub in self.list_subscriptions():
             result = run_sh(
-                ["gcloud", "pubsub", "subscriptions", "delete", sub, f"--project={self.project_id}"]
+                [
+                    "gcloud",
+                    "pubsub",
+                    "subscriptions",
+                    "delete",
+                    sub,
+                    f"--project={self.project_id}",
+                ]
             )
             if "ERROR" in result:
                 logger.error(f"Failed to delete subscription '{sub}': {result}")

--- a/src/aigear/infrastructure/gcp/pub_sub.py
+++ b/src/aigear/infrastructure/gcp/pub_sub.py
@@ -60,7 +60,7 @@ class PubSub:
             )
         return is_exist
 
-    def _delete_subscriptions(self):
+    def list_subscriptions(self) -> list[str]:
         event = run_sh(
             [
                 "gcloud",
@@ -71,8 +71,17 @@ class PubSub:
                 f"--project={self.project_id}",
             ]
         )
-        subscriptions = [line.strip() for line in event.splitlines() if line.strip().startswith("projects/")]
-        for sub in subscriptions:
+        return [
+            line.strip()
+            for line in event.splitlines()
+            if line.strip().startswith("projects/")
+        ]
+
+    def has_subscriptions(self) -> bool:
+        return bool(self.list_subscriptions())
+
+    def _delete_subscriptions(self):
+        for sub in self.list_subscriptions():
             result = run_sh(
                 ["gcloud", "pubsub", "subscriptions", "delete", sub, f"--project={self.project_id}"]
             )

--- a/src/aigear/infrastructure/gcp/pub_sub.py
+++ b/src/aigear/infrastructure/gcp/pub_sub.py
@@ -13,6 +13,90 @@ class PubSub:
         self.topic_name = topic_name
         self.project_id = project_id
 
+    @property
+    def topic_path(self) -> str:
+        return f"projects/{self.project_id}/topics/{self.topic_name}"
+
+    def describe_subscription(self, subscription: str) -> str | None:
+        """
+        Describe a subscription (gcloud pubsub subscriptions describe).
+
+        Returns the topic the subscription is bound to, or None if the
+        subscription does not exist (NOT_FOUND).
+        """
+        sub_id = subscription.rsplit("/", 1)[-1]
+        event = run_sh(
+            [
+                "gcloud",
+                "pubsub",
+                "subscriptions",
+                "describe",
+                sub_id,
+                f"--project={self.project_id}",
+                "--format=value(topic)",
+            ]
+        )
+        if "ERROR" in event:
+            if "NOT_FOUND" in event:
+                return None
+            logger.error(
+                f"Unexpected error describing subscription ({sub_id}): {event}"
+            )
+            return None
+        topic = event.strip()
+        return topic if topic.startswith("projects/") else None
+
+    def subscription_status(self, subscription: str) -> str:
+        """
+        Classify a subscription relative to this topic.
+
+        Returns:
+            healthy  - subscription exists and is bound to this topic
+            orphan   - subscription exists but is bound to another/deleted topic
+            missing  - subscription does not exist
+        """
+        topic = self.describe_subscription(subscription)
+        if topic is None:
+            return "missing"
+        if topic == self.topic_path:
+            return "healthy"
+        return "orphan"
+
+    def delete_subscription(self, subscription: str):
+        sub_id = subscription.rsplit("/", 1)[-1]
+        event = run_sh(
+            [
+                "gcloud",
+                "pubsub",
+                "subscriptions",
+                "delete",
+                sub_id,
+                f"--project={self.project_id}",
+                "--quiet",
+            ]
+        )
+        if "ERROR" in event:
+            logger.warning(
+                f"Could not delete Pub/Sub subscription ({sub_id}): {event.strip()}"
+            )
+        else:
+            logger.info(f"Deleted Pub/Sub subscription ({sub_id}).")
+
+    def find_healthy_subscription(self, candidates: list[str]) -> str | None:
+        """Return the first candidate subscription that is healthy on this topic."""
+        for sub in candidates:
+            if sub and self.subscription_status(sub) == "healthy":
+                return sub
+        return None
+
+    def find_orphan_subscriptions(self, candidates: list[str]) -> list[str]:
+        """Return subscriptions that exist but are not bound to this topic."""
+        return [
+            sub
+            for sub in candidates
+            if sub and self.subscription_status(sub) == "orphan"
+        ]
+
     def create(self):
         command = [
             "gcloud",
@@ -68,33 +152,27 @@ class PubSub:
                 "list-subscriptions",
                 self.topic_name,
                 f"--project={self.project_id}",
+                "--uri",
             ]
         )
-        return [
-            line.strip()
-            for line in event.splitlines()
-            if line.strip().startswith("projects/")
-        ]
+        subs: list[str] = []
+        for line in event.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("projects/"):
+                subs.append(stripped)
+            elif stripped.startswith("name:"):
+                path = stripped.split(":", 1)[1].strip()
+                if path.startswith("projects/"):
+                    subs.append(path)
+        return subs
 
-    def has_subscriptions(self) -> bool:
-        return bool(self.list_subscriptions())
+    def has_healthy_subscription(self, extra_candidates: list[str] | None = None) -> bool:
+        candidates = list(extra_candidates or []) + self.list_subscriptions()
+        return self.find_healthy_subscription(candidates) is not None
 
     def _delete_subscriptions(self):
         for sub in self.list_subscriptions():
-            result = run_sh(
-                [
-                    "gcloud",
-                    "pubsub",
-                    "subscriptions",
-                    "delete",
-                    sub,
-                    f"--project={self.project_id}",
-                ]
-            )
-            if "ERROR" in result:
-                logger.error(f"Failed to delete subscription '{sub}': {result}")
-            else:
-                logger.info(f"Subscription '{sub}' deleted.")
+            self.delete_subscription(sub)
 
     def delete(self):
         self._delete_subscriptions()

--- a/src/aigear/infrastructure/gcp/pub_sub.py
+++ b/src/aigear/infrastructure/gcp/pub_sub.py
@@ -97,6 +97,37 @@ class PubSub:
             if sub and self.subscription_status(sub) == "orphan"
         ]
 
+    def tune_push_subscription(
+        self,
+        subscription: str,
+        *,
+        ack_deadline_sec: int = 300,
+        min_retry_delay_sec: int = 60,
+    ):
+        """
+        Extend push ack deadline and backoff (reduces Pub/Sub redelivery).
+
+        Eventarc defaults to a short ack deadline (~10s); VM insert often needs longer.
+        """
+        sub_id = subscription.rsplit("/", 1)[-1]
+        run_sh(
+            [
+                "gcloud",
+                "pubsub",
+                "subscriptions",
+                "update",
+                sub_id,
+                f"--project={self.project_id}",
+                f"--ack-deadline={ack_deadline_sec}",
+                f"--min-retry-delay={min_retry_delay_sec}s",
+            ],
+            check=True,
+        )
+        logger.info(
+            f"Pub/Sub subscription ({sub_id}): ack-deadline={ack_deadline_sec}s, "
+            f"min-retry-delay={min_retry_delay_sec}s"
+        )
+
     def create(self):
         command = [
             "gcloud",

--- a/tests/infrastructure/gcp/test_eventarc.py
+++ b/tests/infrastructure/gcp/test_eventarc.py
@@ -1,0 +1,75 @@
+from unittest.mock import patch
+
+from aigear.infrastructure.gcp.eventarc import EventarcTrigger, trigger_name_for_function
+
+
+def _make_trigger():
+    return EventarcTrigger(
+        trigger_name="my-fn-pubsub",
+        function_name="my_fn",
+        region="asia-northeast1",
+        topic_name="my-topic",
+        project_id="my-project",
+        trigger_service_account="sa@my-project.iam.gserviceaccount.com",
+    )
+
+
+def test_trigger_name_for_function_normalizes_underscores():
+    assert trigger_name_for_function("test_sklearn_pipeline_run") == (
+        "test-sklearn-pipeline-run-pubsub"
+    )
+
+
+def test_trigger_name_for_function_from_class():
+    trigger = EventarcTrigger.from_function(
+        function_name="My_Function",
+        region="asia-northeast1",
+        topic_name="my-topic",
+        project_id="my-project",
+        trigger_service_account="sa@my-project.iam.gserviceaccount.com",
+    )
+    assert trigger.trigger_name == "my-function-pubsub"
+    assert trigger.transport_topic == "projects/my-project/topics/my-topic"
+
+
+@patch("aigear.infrastructure.gcp.eventarc.run_sh")
+def test_describe_returns_true_when_trigger_exists(mock_run_sh):
+    mock_run_sh.return_value = (
+        "name: projects/my-project/locations/asia-northeast1/triggers/my-fn-pubsub"
+    )
+    assert _make_trigger().describe() is True
+
+
+@patch("aigear.infrastructure.gcp.eventarc.run_sh")
+def test_describe_returns_false_when_not_found(mock_run_sh):
+    mock_run_sh.return_value = "ERROR: NOT_FOUND"
+    assert _make_trigger().describe() is False
+
+
+@patch("aigear.infrastructure.gcp.eventarc.run_sh")
+def test_create_builds_expected_command(mock_run_sh):
+    trigger = _make_trigger()
+    trigger.create()
+    cmd = mock_run_sh.call_args[0][0]
+    assert cmd[0:3] == ["gcloud", "eventarc", "triggers"]
+    assert "create" in cmd
+    assert "my-fn-pubsub" in cmd
+    assert "--destination-run-service=my_fn" in cmd
+    assert (
+        "--transport-topic=projects/my-project/topics/my-topic" in cmd
+    )
+    assert (
+        "--event-filters=type=google.cloud.pubsub.topic.v1.messagePublished"
+        in cmd
+    )
+    mock_run_sh.assert_called_once()
+    assert mock_run_sh.call_args[1]["check"] is True
+
+
+@patch("aigear.infrastructure.gcp.eventarc.run_sh")
+def test_add_permissions_grants_event_receiver(mock_run_sh):
+    trigger = _make_trigger()
+    trigger.add_permissions(sa_email="sa@my-project.iam.gserviceaccount.com")
+    cmd = " ".join(mock_run_sh.call_args[0][0])
+    assert "add-iam-policy-binding" in cmd
+    assert "roles/eventarc.eventReceiver" in cmd

--- a/tests/infrastructure/gcp/test_eventarc.py
+++ b/tests/infrastructure/gcp/test_eventarc.py
@@ -1,41 +1,33 @@
 from unittest.mock import patch
 
-from aigear.infrastructure.gcp.eventarc import EventarcTrigger, trigger_name_for_function
+from aigear.infrastructure.gcp.eventarc import EventarcPubSubTrigger, pubsub_trigger_name
 
 
 def _make_trigger():
-    return EventarcTrigger(
+    return EventarcPubSubTrigger(
         trigger_name="my-fn-pubsub",
-        function_name="my_fn",
-        region="asia-northeast1",
-        topic_name="my-topic",
+        location="asia-northeast1",
         project_id="my-project",
+        function_name="my-fn",
+        function_region="asia-northeast1",
+        topic_name="my-topic",
         trigger_service_account="sa@my-project.iam.gserviceaccount.com",
     )
 
 
-def test_trigger_name_for_function_normalizes_underscores():
-    assert trigger_name_for_function("test_sklearn_pipeline_run") == (
-        "test-sklearn-pipeline-run-pubsub"
-    )
+def test_pubsub_trigger_name_suffix():
+    assert pubsub_trigger_name("my-fn") == "my-fn-pubsub"
 
 
-def test_trigger_name_for_function_from_class():
-    trigger = EventarcTrigger.from_function(
-        function_name="My_Function",
-        region="asia-northeast1",
-        topic_name="my-topic",
-        project_id="my-project",
-        trigger_service_account="sa@my-project.iam.gserviceaccount.com",
-    )
-    assert trigger.trigger_name == "my-function-pubsub"
+def test_transport_topic_path():
+    trigger = _make_trigger()
     assert trigger.transport_topic == "projects/my-project/topics/my-topic"
 
 
 @patch("aigear.infrastructure.gcp.eventarc.run_sh")
 def test_describe_returns_true_when_trigger_exists(mock_run_sh):
     mock_run_sh.return_value = (
-        "name: projects/my-project/locations/asia-northeast1/triggers/my-fn-pubsub"
+        "name: projects/my-project/locations/asia-northeast1/triggers/my-fn-pubsub\n"
     )
     assert _make_trigger().describe() is True
 
@@ -47,29 +39,44 @@ def test_describe_returns_false_when_not_found(mock_run_sh):
 
 
 @patch("aigear.infrastructure.gcp.eventarc.run_sh")
-def test_create_builds_expected_command(mock_run_sh):
+def test_create_matches_official_gcloud_flags(mock_run_sh):
     trigger = _make_trigger()
     trigger.create()
     cmd = mock_run_sh.call_args[0][0]
-    assert cmd[0:3] == ["gcloud", "eventarc", "triggers"]
-    assert "create" in cmd
+    assert cmd[:4] == ["gcloud", "eventarc", "triggers", "create"]
     assert "my-fn-pubsub" in cmd
-    assert "--destination-run-service=my_fn" in cmd
+    assert "--destination-run-service=my-fn" in cmd
+    assert "--destination-run-region=asia-northeast1" in cmd
     assert (
-        "--transport-topic=projects/my-project/topics/my-topic" in cmd
+        '--event-filters=type=google.cloud.pubsub.topic.v1.messagePublished' in cmd
     )
+    assert "--transport-topic=projects/my-project/topics/my-topic" in cmd
     assert (
-        "--event-filters=type=google.cloud.pubsub.topic.v1.messagePublished"
-        in cmd
+        "--service-account=sa@my-project.iam.gserviceaccount.com" in cmd
     )
-    mock_run_sh.assert_called_once()
-    assert mock_run_sh.call_args[1]["check"] is True
 
 
 @patch("aigear.infrastructure.gcp.eventarc.run_sh")
-def test_add_permissions_grants_event_receiver(mock_run_sh):
-    trigger = _make_trigger()
-    trigger.add_permissions(sa_email="sa@my-project.iam.gserviceaccount.com")
-    cmd = " ".join(mock_run_sh.call_args[0][0])
-    assert "add-iam-policy-binding" in cmd
-    assert "roles/eventarc.eventReceiver" in cmd
+def test_add_trigger_permissions_grants_event_receiver(mock_run_sh):
+    _make_trigger().add_trigger_permissions()
+    cmd = mock_run_sh.call_args[0][0]
+    joined = " ".join(cmd)
+    assert "add-iam-policy-binding" in joined
+    assert "roles/eventarc.eventReceiver" in joined
+
+
+@patch("aigear.infrastructure.gcp.eventarc.run_sh")
+def test_delete_builds_correct_command(mock_run_sh):
+    mock_run_sh.return_value = ""
+    _make_trigger().delete()
+    cmd = mock_run_sh.call_args[0][0]
+    assert cmd == [
+        "gcloud",
+        "eventarc",
+        "triggers",
+        "delete",
+        "my-fn-pubsub",
+        "--location=asia-northeast1",
+        "--project=my-project",
+        "--quiet",
+    ]

--- a/tests/infrastructure/gcp/test_eventarc.py
+++ b/tests/infrastructure/gcp/test_eventarc.py
@@ -56,13 +56,33 @@ def test_create_matches_official_gcloud_flags(mock_run_sh):
     )
 
 
+@patch("aigear.infrastructure.gcp.pub_sub.PubSub.has_subscriptions", return_value=True)
 @patch("aigear.infrastructure.gcp.eventarc.run_sh")
-def test_add_trigger_permissions_grants_event_receiver(mock_run_sh):
-    _make_trigger().add_trigger_permissions()
-    cmd = mock_run_sh.call_args[0][0]
-    joined = " ".join(cmd)
-    assert "add-iam-policy-binding" in joined
-    assert "roles/eventarc.eventReceiver" in joined
+def test_ensure_creates_trigger_when_missing(mock_run_sh, _mock_subs):
+    trigger = _make_trigger()
+    with patch.object(trigger, "describe", side_effect=[False, True]):
+        trigger.ensure()
+    assert mock_run_sh.call_count >= 2
+
+
+@patch("aigear.infrastructure.gcp.pub_sub.PubSub.has_subscriptions", return_value=False)
+@patch("aigear.infrastructure.gcp.eventarc.run_sh")
+def test_ensure_raises_when_no_subscription(mock_run_sh, _mock_subs):
+    trigger = _make_trigger()
+    with patch.object(trigger, "describe", return_value=True):
+        try:
+            trigger.ensure()
+            assert False, "expected RuntimeError"
+        except RuntimeError as exc:
+            assert "no subscription" in str(exc).lower()
+
+
+@patch("aigear.infrastructure.gcp.eventarc.run_sh")
+def test_delete_if_exists_skips_when_missing(mock_run_sh):
+    trigger = _make_trigger()
+    with patch.object(trigger, "describe", return_value=False):
+        trigger.delete_if_exists()
+    mock_run_sh.assert_not_called()
 
 
 @patch("aigear.infrastructure.gcp.eventarc.run_sh")

--- a/tests/infrastructure/gcp/test_eventarc.py
+++ b/tests/infrastructure/gcp/test_eventarc.py
@@ -25,11 +25,13 @@ def test_transport_topic_path():
 
 
 @patch("aigear.infrastructure.gcp.eventarc.run_sh")
-def test_describe_returns_true_when_trigger_exists(mock_run_sh):
+def test_describe_transport_parses_subscription(mock_run_sh):
     mock_run_sh.return_value = (
-        "name: projects/my-project/locations/asia-northeast1/triggers/my-fn-pubsub\n"
+        "my-fn-pubsub\tprojects/my-project/subscriptions/eventarc-sub\n"
     )
-    assert _make_trigger().describe() is True
+    exists, sub = _make_trigger()._describe_transport()
+    assert exists is True
+    assert sub == "projects/my-project/subscriptions/eventarc-sub"
 
 
 @patch("aigear.infrastructure.gcp.eventarc.run_sh")
@@ -56,25 +58,69 @@ def test_create_matches_official_gcloud_flags(mock_run_sh):
     )
 
 
-@patch("aigear.infrastructure.gcp.pub_sub.PubSub.has_subscriptions", return_value=True)
 @patch("aigear.infrastructure.gcp.eventarc.run_sh")
-def test_ensure_creates_trigger_when_missing(mock_run_sh, _mock_subs):
+def test_ensure_fast_path_when_subscription_healthy(mock_run_sh):
     trigger = _make_trigger()
-    with patch.object(trigger, "describe", side_effect=[False, True]):
-        trigger.ensure()
+    transport_sub = "projects/my-project/subscriptions/eventarc-sub"
+    with patch.object(trigger, "create") as mock_create:
+        with patch.object(
+            trigger, "_describe_transport", return_value=(True, transport_sub)
+        ):
+            with patch.object(trigger, "_is_ready", return_value=True):
+                with patch(
+                    "aigear.infrastructure.gcp.pub_sub.PubSub.find_healthy_subscription",
+                    return_value=transport_sub,
+                ):
+                    trigger.ensure()
+    mock_create.assert_not_called()
+
+
+@patch("aigear.infrastructure.gcp.eventarc.run_sh")
+def test_ensure_creates_trigger_when_missing(mock_run_sh):
+    trigger = _make_trigger()
+    with patch.object(trigger, "_wait_for_ready", return_value=True):
+        with patch.object(trigger, "_describe_transport", return_value=(False, None)):
+            trigger.ensure()
     assert mock_run_sh.call_count >= 2
 
 
-@patch("aigear.infrastructure.gcp.pub_sub.PubSub.has_subscriptions", return_value=False)
+@patch("aigear.infrastructure.gcp.eventarc.time.sleep")
 @patch("aigear.infrastructure.gcp.eventarc.run_sh")
-def test_ensure_raises_when_no_subscription(mock_run_sh, _mock_subs):
+def test_ensure_raises_when_no_healthy_subscription(mock_run_sh, _mock_sleep):
     trigger = _make_trigger()
-    with patch.object(trigger, "describe", return_value=True):
-        try:
-            trigger.ensure()
-            assert False, "expected RuntimeError"
-        except RuntimeError as exc:
-            assert "no subscription" in str(exc).lower()
+    with patch.object(trigger, "_delete_orphan_subscriptions"):
+        with patch.object(trigger, "_describe_transport", return_value=(False, None)):
+            with patch.object(trigger, "_wait_for_ready", return_value=False):
+                try:
+                    trigger.ensure()
+                    assert False, "expected RuntimeError"
+                except RuntimeError as exc:
+                    assert "healthy" in str(exc).lower()
+
+
+@patch("aigear.infrastructure.gcp.eventarc.time.sleep")
+@patch("aigear.infrastructure.gcp.eventarc.run_sh")
+def test_ensure_recreates_orphan_trigger(mock_run_sh, _mock_sleep):
+    trigger = _make_trigger()
+    transport_sub = "projects/my-project/subscriptions/eventarc-sub"
+    with patch.object(trigger, "_grant_event_receiver") as mock_grant:
+        with patch.object(trigger, "delete", return_value=True) as mock_delete:
+            with patch.object(trigger, "create") as mock_create:
+                with patch.object(trigger, "_wait_for_ready", return_value=True):
+                    with patch.object(
+                        trigger,
+                        "_describe_transport",
+                        return_value=(True, transport_sub),
+                    ):
+                        with patch.object(trigger, "_is_ready", return_value=False):
+                            with patch.object(
+                                trigger, "_delete_orphan_subscriptions"
+                            ) as mock_cleanup:
+                                trigger.ensure()
+    mock_cleanup.assert_called_once()
+    mock_delete.assert_called_once()
+    mock_create.assert_called_once()
+    mock_grant.assert_not_called()
 
 
 @patch("aigear.infrastructure.gcp.eventarc.run_sh")
@@ -88,7 +134,7 @@ def test_delete_if_exists_skips_when_missing(mock_run_sh):
 @patch("aigear.infrastructure.gcp.eventarc.run_sh")
 def test_delete_builds_correct_command(mock_run_sh):
     mock_run_sh.return_value = ""
-    _make_trigger().delete()
+    assert _make_trigger().delete() is True
     cmd = mock_run_sh.call_args[0][0]
     assert cmd == [
         "gcloud",

--- a/tests/infrastructure/gcp/test_eventarc.py
+++ b/tests/infrastructure/gcp/test_eventarc.py
@@ -67,12 +67,14 @@ def test_ensure_fast_path_when_subscription_healthy(mock_run_sh):
             trigger, "_describe_transport", return_value=(True, transport_sub)
         ):
             with patch.object(trigger, "_is_ready", return_value=True):
-                with patch(
-                    "aigear.infrastructure.gcp.pub_sub.PubSub.find_healthy_subscription",
-                    return_value=transport_sub,
-                ):
-                    trigger.ensure()
+                with patch.object(trigger, "_tune_push_subscription") as mock_tune:
+                    with patch(
+                        "aigear.infrastructure.gcp.pub_sub.PubSub.find_healthy_subscription",
+                        return_value=transport_sub,
+                    ):
+                        trigger.ensure()
     mock_create.assert_not_called()
+    mock_tune.assert_called_once()
 
 
 @patch("aigear.infrastructure.gcp.eventarc.run_sh")

--- a/tests/infrastructure/gcp/test_function.py
+++ b/tests/infrastructure/gcp/test_function.py
@@ -1,0 +1,38 @@
+from unittest.mock import patch
+
+from aigear.infrastructure.gcp.function import CloudFunction
+
+
+def _make_function():
+    return CloudFunction(
+        function_name="my-fn",
+        region="asia-northeast1",
+        entry_point="handler",
+        topic_name="my-topic",
+        project_id="my-project",
+        service_account="sa@my-project.iam.gserviceaccount.com",
+    )
+
+
+@patch("aigear.infrastructure.gcp.function.run_sh")
+def test_ensure_deploys_when_missing(mock_run_sh):
+    fn = _make_function()
+    with patch.object(fn, "describe", return_value=False), patch.object(
+        fn, "deploy"
+    ) as mock_deploy, patch.object(
+        fn, "add_permissions_to_cloud_function"
+    ) as mock_perms:
+        fn.ensure("invoker@my-project.iam.gserviceaccount.com")
+    mock_deploy.assert_called_once()
+    mock_perms.assert_called_once_with(sa_email="invoker@my-project.iam.gserviceaccount.com")
+
+
+@patch("aigear.infrastructure.gcp.function.run_sh")
+def test_ensure_skips_deploy_when_exists(mock_run_sh):
+    fn = _make_function()
+    with patch.object(fn, "describe", return_value=True), patch.object(
+        fn, "deploy"
+    ) as mock_deploy, patch.object(fn, "add_permissions_to_cloud_function") as mock_perms:
+        fn.ensure("invoker@my-project.iam.gserviceaccount.com")
+    mock_deploy.assert_not_called()
+    mock_perms.assert_called_once()

--- a/tests/infrastructure/gcp/test_infra_ensure.py
+++ b/tests/infrastructure/gcp/test_infra_ensure.py
@@ -127,45 +127,6 @@ def test_ensure_pubsub_skips_when_exists():
     infra.pubsub.create.assert_not_called()
 
 
-# ── _ensure_cloud_function / _ensure_eventarc_trigger ──────────────────────────
-
-
-def test_ensure_cloud_function_deploys_when_not_exists():
-    infra = _make_infra()
-    infra.cloud_function.describe.return_value = False
-    infra._ensure_cloud_function()
-    infra.cloud_function.deploy.assert_called_once()
-    infra.cloud_function.add_permissions_to_cloud_function.assert_called_once()
-
-
-def test_ensure_cloud_function_skips_deploy_when_exists():
-    infra = _make_infra()
-    infra.cloud_function.describe.return_value = True
-    infra._ensure_cloud_function()
-    infra.cloud_function.deploy.assert_not_called()
-    infra.cloud_function.add_permissions_to_cloud_function.assert_called_once()
-
-
-def test_ensure_eventarc_trigger_creates_when_missing():
-    infra = _make_infra()
-    infra.eventarc_trigger.describe.return_value = False
-    infra.pubsub.has_subscriptions.return_value = True
-    infra._ensure_eventarc_trigger()
-    infra.eventarc_trigger.add_trigger_permissions.assert_called_once()
-    infra.eventarc_trigger.create.assert_called_once()
-
-
-def test_ensure_eventarc_trigger_raises_when_no_subscription():
-    infra = _make_infra()
-    infra.eventarc_trigger.describe.return_value = True
-    infra.pubsub.has_subscriptions.return_value = False
-    try:
-        infra._ensure_eventarc_trigger()
-        assert False, "expected RuntimeError"
-    except RuntimeError as exc:
-        assert "no subscription" in str(exc).lower()
-
-
 # ── _ensure_cloud_build ───────────────────────────────────────────────────────
 
 

--- a/tests/infrastructure/gcp/test_infra_ensure.py
+++ b/tests/infrastructure/gcp/test_infra_ensure.py
@@ -39,6 +39,7 @@ def _make_infra():
 
 # ── _ensure_service_account ───────────────────────────────────────────────────
 
+
 def test_ensure_service_account_creates_when_not_exists():
     infra = _make_infra()
     infra.service_accounts.describe.return_value = False
@@ -57,6 +58,7 @@ def test_ensure_service_account_skips_create_when_exists():
 
 # ── _ensure_model_bucket ──────────────────────────────────────────────────────
 
+
 def test_ensure_model_bucket_creates_and_grants_permissions_when_not_exists():
     infra = _make_infra()
     infra.model_bucket.describe.return_value = False
@@ -73,6 +75,7 @@ def test_ensure_model_bucket_skips_when_exists():
 
 
 # ── _ensure_release_bucket ────────────────────────────────────────────────────
+
 
 def test_ensure_release_bucket_creates_when_not_exists():
     infra = _make_infra()
@@ -91,6 +94,7 @@ def test_ensure_release_bucket_skips_when_exists():
 
 # ── _ensure_artifacts ─────────────────────────────────────────────────────────
 
+
 def test_ensure_artifacts_creates_when_not_exists():
     infra = _make_infra()
     infra.artifacts.describe.return_value = False
@@ -107,6 +111,7 @@ def test_ensure_artifacts_skips_when_exists():
 
 # ── _ensure_pubsub ────────────────────────────────────────────────────────────
 
+
 def test_ensure_pubsub_creates_and_grants_permissions_when_not_exists():
     infra = _make_infra()
     infra.pubsub.describe.return_value = False
@@ -122,7 +127,8 @@ def test_ensure_pubsub_skips_when_exists():
     infra.pubsub.create.assert_not_called()
 
 
-# ── _ensure_cloud_function ────────────────────────────────────────────────────
+# ── _ensure_cloud_function / _ensure_eventarc_trigger ──────────────────────────
+
 
 def test_ensure_cloud_function_deploys_when_not_exists():
     infra = _make_infra()
@@ -132,30 +138,21 @@ def test_ensure_cloud_function_deploys_when_not_exists():
     infra.cloud_function.add_permissions_to_cloud_function.assert_called_once()
 
 
-def test_ensure_cloud_function_skips_when_exists():
+def test_ensure_cloud_function_skips_deploy_when_exists():
     infra = _make_infra()
     infra.cloud_function.describe.return_value = True
     infra._ensure_cloud_function()
     infra.cloud_function.deploy.assert_not_called()
+    infra.cloud_function.add_permissions_to_cloud_function.assert_called_once()
 
 
-# ── _ensure_eventarc_trigger ──────────────────────────────────────────────────
-
-def test_ensure_eventarc_trigger_creates_when_not_exists():
+def test_ensure_eventarc_trigger_creates_when_missing():
     infra = _make_infra()
     infra.eventarc_trigger.describe.return_value = False
     infra.pubsub.has_subscriptions.return_value = True
     infra._ensure_eventarc_trigger()
-    infra.eventarc_trigger.add_permissions.assert_called_once()
+    infra.eventarc_trigger.add_trigger_permissions.assert_called_once()
     infra.eventarc_trigger.create.assert_called_once()
-
-
-def test_ensure_eventarc_trigger_skips_create_when_exists():
-    infra = _make_infra()
-    infra.eventarc_trigger.describe.return_value = True
-    infra.pubsub.has_subscriptions.return_value = True
-    infra._ensure_eventarc_trigger()
-    infra.eventarc_trigger.create.assert_not_called()
 
 
 def test_ensure_eventarc_trigger_raises_when_no_subscription():
@@ -169,21 +166,8 @@ def test_ensure_eventarc_trigger_raises_when_no_subscription():
         assert "no subscription" in str(exc).lower()
 
 
-def test_delete_eventarc_trigger_deletes_when_exists():
-    infra = _make_infra()
-    infra.eventarc_trigger.describe.return_value = True
-    infra._delete_eventarc_trigger()
-    infra.eventarc_trigger.delete.assert_called_once()
-
-
-def test_delete_eventarc_trigger_skips_when_not_exists():
-    infra = _make_infra()
-    infra.eventarc_trigger.describe.return_value = False
-    infra._delete_eventarc_trigger()
-    infra.eventarc_trigger.delete.assert_not_called()
-
-
 # ── _ensure_cloud_build ───────────────────────────────────────────────────────
+
 
 def test_ensure_cloud_build_creates_when_not_exists():
     infra = _make_infra()
@@ -201,6 +185,7 @@ def test_ensure_cloud_build_skips_when_exists():
 
 # ── _ensure_kubernetes_cluster ────────────────────────────────────────────────
 
+
 def test_ensure_kubernetes_creates_when_not_exists():
     infra = _make_infra()
     infra.kubernetes_cluster.describe.return_value = False
@@ -216,6 +201,7 @@ def test_ensure_kubernetes_skips_when_exists():
 
 
 # ── _ensure_kms ───────────────────────────────────────────────────────────────
+
 
 def test_ensure_kms_creates_keyring_and_key_when_neither_exists():
     infra = _make_infra()
@@ -250,6 +236,7 @@ def test_ensure_kms_skips_all_when_everything_exists():
 
 
 # ── _delete_* methods ─────────────────────────────────────────────────────────
+
 
 def test_delete_model_bucket_calls_delete_when_exists():
     infra = _make_infra()
@@ -337,6 +324,7 @@ def test_delete_pubsub_skips_when_not_exists():
 
 # ── _status_check ─────────────────────────────────────────────────────────────
 
+
 def test_status_check_returns_exists_when_check_fn_returns_true():
     infra = _make_infra()
     _, config_on, status = infra._status_check("My Resource", True, lambda: True)
@@ -375,6 +363,7 @@ def test_status_check_passes_through_string_result():
 
 # ── _status_kms ───────────────────────────────────────────────────────────────
 
+
 def test_status_kms_returns_not_found_when_no_keyring():
     infra = _make_infra()
     infra.cloud_kms.describe_keyring.return_value = False
@@ -411,9 +400,12 @@ def test_status_kms_returns_disabled_when_no_enabled_version():
 
 # ── _build_substitutions ──────────────────────────────────────────────────────
 
+
 def test_build_substitutions_contains_expected_keys():
     infra = _make_infra()
-    with patch("aigear.infrastructure.gcp.infra.get_image_name", return_value="my-image"):
+    with patch(
+        "aigear.infrastructure.gcp.infra.get_image_name", return_value="my-image"
+    ):
         result = infra._build_substitutions()
     assert "_ENVIRONMENT=staging" in result
     assert "_KMS_KEYRING=my-keyring" in result

--- a/tests/infrastructure/gcp/test_infra_ensure.py
+++ b/tests/infrastructure/gcp/test_infra_ensure.py
@@ -31,6 +31,8 @@ def _make_infra():
     infra.cloud_kms = MagicMock()
     infra.cloud_build = MagicMock()
     infra.cloud_function = MagicMock()
+    infra.eventarc_trigger = MagicMock()
+    infra.eventarc_trigger.trigger_name = "my-function-pubsub"
     infra.kubernetes_cluster = MagicMock()
     return infra
 
@@ -118,6 +120,67 @@ def test_ensure_pubsub_skips_when_exists():
     infra.pubsub.describe.return_value = True
     infra._ensure_pubsub()
     infra.pubsub.create.assert_not_called()
+
+
+# ── _ensure_cloud_function ────────────────────────────────────────────────────
+
+def test_ensure_cloud_function_deploys_when_not_exists():
+    infra = _make_infra()
+    infra.cloud_function.describe.return_value = False
+    infra._ensure_cloud_function()
+    infra.cloud_function.deploy.assert_called_once()
+    infra.cloud_function.add_permissions_to_cloud_function.assert_called_once()
+
+
+def test_ensure_cloud_function_skips_when_exists():
+    infra = _make_infra()
+    infra.cloud_function.describe.return_value = True
+    infra._ensure_cloud_function()
+    infra.cloud_function.deploy.assert_not_called()
+
+
+# ── _ensure_eventarc_trigger ──────────────────────────────────────────────────
+
+def test_ensure_eventarc_trigger_creates_when_not_exists():
+    infra = _make_infra()
+    infra.eventarc_trigger.describe.return_value = False
+    infra.pubsub.has_subscriptions.return_value = True
+    infra._ensure_eventarc_trigger()
+    infra.eventarc_trigger.add_permissions.assert_called_once()
+    infra.eventarc_trigger.create.assert_called_once()
+
+
+def test_ensure_eventarc_trigger_skips_create_when_exists():
+    infra = _make_infra()
+    infra.eventarc_trigger.describe.return_value = True
+    infra.pubsub.has_subscriptions.return_value = True
+    infra._ensure_eventarc_trigger()
+    infra.eventarc_trigger.create.assert_not_called()
+
+
+def test_ensure_eventarc_trigger_raises_when_no_subscription():
+    infra = _make_infra()
+    infra.eventarc_trigger.describe.return_value = True
+    infra.pubsub.has_subscriptions.return_value = False
+    try:
+        infra._ensure_eventarc_trigger()
+        assert False, "expected RuntimeError"
+    except RuntimeError as exc:
+        assert "no subscription" in str(exc).lower()
+
+
+def test_delete_eventarc_trigger_deletes_when_exists():
+    infra = _make_infra()
+    infra.eventarc_trigger.describe.return_value = True
+    infra._delete_eventarc_trigger()
+    infra.eventarc_trigger.delete.assert_called_once()
+
+
+def test_delete_eventarc_trigger_skips_when_not_exists():
+    infra = _make_infra()
+    infra.eventarc_trigger.describe.return_value = False
+    infra._delete_eventarc_trigger()
+    infra.eventarc_trigger.delete.assert_not_called()
 
 
 # ── _ensure_cloud_build ───────────────────────────────────────────────────────

--- a/tests/infrastructure/gcp/test_pub_sub.py
+++ b/tests/infrastructure/gcp/test_pub_sub.py
@@ -69,6 +69,25 @@ def test_add_permissions_uses_full_topic_path(mock_run_sh):
     assert "projects/my-project/topics/my-topic" in all_calls
 
 
+# ── PubSub.list_subscriptions / has_subscriptions ─────────────────────────────
+
+@patch("aigear.infrastructure.gcp.pub_sub.run_sh")
+def test_list_subscriptions_parses_project_paths(mock_run_sh):
+    mock_run_sh.return_value = (
+        "projects/my-project/subscriptions/eventarc-asia-northeast1-fn-sub-001\n"
+    )
+    subs = _make_pubsub().list_subscriptions()
+    assert subs == [
+        "projects/my-project/subscriptions/eventarc-asia-northeast1-fn-sub-001"
+    ]
+
+
+@patch("aigear.infrastructure.gcp.pub_sub.run_sh")
+def test_has_subscriptions_returns_false_when_none(mock_run_sh):
+    mock_run_sh.return_value = ""
+    assert _make_pubsub().has_subscriptions() is False
+
+
 # ── PubSub.delete ─────────────────────────────────────────────────────────────
 
 @patch("aigear.infrastructure.gcp.pub_sub.run_sh")

--- a/tests/infrastructure/gcp/test_pub_sub.py
+++ b/tests/infrastructure/gcp/test_pub_sub.py
@@ -117,6 +117,18 @@ def test_find_orphan_subscriptions(mock_run_sh):
     assert orphans == ["projects/my-project/subscriptions/orphan-sub"]
 
 
+@patch("aigear.infrastructure.gcp.pub_sub.run_sh")
+def test_tune_push_subscription_updates_ack_and_retry(mock_run_sh):
+    ps = _make_pubsub()
+    sub = "projects/my-project/subscriptions/eventarc-sub"
+    ps.tune_push_subscription(sub, ack_deadline_sec=300, min_retry_delay_sec=60)
+    cmd = mock_run_sh.call_args[0][0]
+    assert cmd[:4] == ["gcloud", "pubsub", "subscriptions", "update"]
+    assert cmd[4] == "eventarc-sub"
+    assert "--ack-deadline=300" in cmd
+    assert "--min-retry-delay=60s" in cmd
+
+
 # ── PubSub.add_permissions_to_pubsub ─────────────────────────────────────────
 
 @patch("aigear.infrastructure.gcp.pub_sub.run_sh")

--- a/tests/infrastructure/gcp/test_pub_sub.py
+++ b/tests/infrastructure/gcp/test_pub_sub.py
@@ -49,6 +49,74 @@ def test_describe_returns_false_when_name_not_in_output(mock_run_sh):
     assert ps.describe() is False
 
 
+# ── PubSub.describe_subscription / subscription_status ──────────────────────
+
+
+@patch("aigear.infrastructure.gcp.pub_sub.run_sh")
+def test_describe_subscription_uses_gcloud_describe(mock_run_sh):
+    mock_run_sh.return_value = "projects/my-project/topics/my-topic\n"
+    ps = _make_pubsub()
+    sub = "projects/my-project/subscriptions/my-sub"
+    assert ps.describe_subscription(sub) == "projects/my-project/topics/my-topic"
+    cmd = mock_run_sh.call_args[0][0]
+    assert cmd[:4] == ["gcloud", "pubsub", "subscriptions", "describe"]
+    assert cmd[4] == "my-sub"
+    assert "--format=value(topic)" in cmd
+
+
+@patch("aigear.infrastructure.gcp.pub_sub.run_sh")
+def test_describe_subscription_returns_none_when_missing(mock_run_sh):
+    mock_run_sh.return_value = "ERROR: NOT_FOUND"
+    ps = _make_pubsub()
+    assert ps.describe_subscription("projects/my-project/subscriptions/gone") is None
+
+
+@patch("aigear.infrastructure.gcp.pub_sub.run_sh")
+def test_subscription_status_healthy(mock_run_sh):
+    mock_run_sh.return_value = "projects/my-project/topics/my-topic\n"
+    ps = _make_pubsub()
+    assert (
+        ps.subscription_status("projects/my-project/subscriptions/sub")
+        == "healthy"
+    )
+
+
+@patch("aigear.infrastructure.gcp.pub_sub.run_sh")
+def test_subscription_status_orphan(mock_run_sh):
+    mock_run_sh.return_value = "projects/my-project/topics/other-topic\n"
+    ps = _make_pubsub()
+    assert (
+        ps.subscription_status("projects/my-project/subscriptions/sub")
+        == "orphan"
+    )
+
+
+@patch("aigear.infrastructure.gcp.pub_sub.run_sh")
+def test_subscription_status_missing(mock_run_sh):
+    mock_run_sh.return_value = "ERROR: NOT_FOUND"
+    ps = _make_pubsub()
+    assert (
+        ps.subscription_status("projects/my-project/subscriptions/sub")
+        == "missing"
+    )
+
+
+@patch("aigear.infrastructure.gcp.pub_sub.run_sh")
+def test_find_orphan_subscriptions(mock_run_sh):
+    mock_run_sh.side_effect = [
+        "projects/my-project/topics/deleted-topic\n",
+        "projects/my-project/topics/my-topic\n",
+    ]
+    ps = _make_pubsub()
+    orphans = ps.find_orphan_subscriptions(
+        [
+            "projects/my-project/subscriptions/orphan-sub",
+            "projects/my-project/subscriptions/good-sub",
+        ]
+    )
+    assert orphans == ["projects/my-project/subscriptions/orphan-sub"]
+
+
 # ── PubSub.add_permissions_to_pubsub ─────────────────────────────────────────
 
 @patch("aigear.infrastructure.gcp.pub_sub.run_sh")
@@ -69,21 +137,24 @@ def test_add_permissions_uses_full_topic_path(mock_run_sh):
     assert "projects/my-project/topics/my-topic" in all_calls
 
 
-# ── PubSub.list_subscriptions / has_subscriptions ─────────────────────────────
+# ── PubSub.list_subscriptions / has_healthy_subscription ──────────────────────
 
 
 @patch("aigear.infrastructure.gcp.pub_sub.run_sh")
-def test_has_subscriptions_returns_true_when_any_exist(mock_run_sh):
+def test_list_subscriptions_uses_uri(mock_run_sh):
     mock_run_sh.return_value = "projects/my-project/subscriptions/eventarc-sub"
     ps = _make_pubsub()
-    assert ps.has_subscriptions() is True
+    assert ps.list_subscriptions() == ["projects/my-project/subscriptions/eventarc-sub"]
+    assert "--uri" in mock_run_sh.call_args[0][0]
 
 
 @patch("aigear.infrastructure.gcp.pub_sub.run_sh")
-def test_has_subscriptions_returns_false_when_none(mock_run_sh):
-    mock_run_sh.return_value = ""
+def test_has_healthy_subscription_via_describe(mock_run_sh):
+    mock_run_sh.return_value = "projects/my-project/topics/my-topic\n"
     ps = _make_pubsub()
-    assert ps.has_subscriptions() is False
+    assert ps.has_healthy_subscription(
+        ["projects/my-project/subscriptions/eventarc-sub"]
+    ) is True
 
 
 # ── PubSub.delete ─────────────────────────────────────────────────────────────

--- a/tests/infrastructure/gcp/test_pub_sub.py
+++ b/tests/infrastructure/gcp/test_pub_sub.py
@@ -71,21 +71,19 @@ def test_add_permissions_uses_full_topic_path(mock_run_sh):
 
 # ── PubSub.list_subscriptions / has_subscriptions ─────────────────────────────
 
+
 @patch("aigear.infrastructure.gcp.pub_sub.run_sh")
-def test_list_subscriptions_parses_project_paths(mock_run_sh):
-    mock_run_sh.return_value = (
-        "projects/my-project/subscriptions/eventarc-asia-northeast1-fn-sub-001\n"
-    )
-    subs = _make_pubsub().list_subscriptions()
-    assert subs == [
-        "projects/my-project/subscriptions/eventarc-asia-northeast1-fn-sub-001"
-    ]
+def test_has_subscriptions_returns_true_when_any_exist(mock_run_sh):
+    mock_run_sh.return_value = "projects/my-project/subscriptions/eventarc-sub"
+    ps = _make_pubsub()
+    assert ps.has_subscriptions() is True
 
 
 @patch("aigear.infrastructure.gcp.pub_sub.run_sh")
 def test_has_subscriptions_returns_false_when_none(mock_run_sh):
     mock_run_sh.return_value = ""
-    assert _make_pubsub().has_subscriptions() is False
+    ps = _make_pubsub()
+    assert ps.has_subscriptions() is False
 
 
 # ── PubSub.delete ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

This PR fixes a gap where `aigear-infra --create` could leave a Pub/Sub **topic** without a **subscription**, so messages published to the topic (e.g. from Cloud Scheduler) never reached the Cloud Function.

The root cause was relying on `gcloud functions deploy --trigger-topic` while skipping deployment when the Cloud Run service already existed. Topic creation order alone does not create subscriptions—subscriptions are created by **Eventarc** when a Pub/Sub trigger is provisioned.

The implementation follows Google Cloud’s recommended **two-step** flow:

1. Deploy the Cloud Function (no Pub/Sub trigger flags).
2. Create an Eventarc trigger bound to the topic (`gcloud eventarc triggers create`).

## Additional fixes
* Orphan trigger / subscription repair: If an Eventarc trigger exists but the topic has no healthy subscription (e.g. topic, subscription, or function was deleted manually), --create cleans stale Eventarc subscriptions, deletes the trigger, and recreates it.
* Push delivery tuning: After the trigger is ready, tune the Eventarc-managed push subscription (ack-deadline=300s, min-retry-delay=60s) and set the Cloud Function request timeout to 300s so long VM inserts are less likely to cause Pub/Sub redelivery (closer to the old --trigger-topic behavior where ack aligned with function timeout).
* Cloud Function runtime: On Pub/Sub redelivery, skip VM insert when a VM with the same name already exists; fail fast on insert errors; treat Compute “not found” as missing VM in existence checks.
Infra orchestration: Three-phase --create / reverse-order --delete; delete topic subscriptions before deleting the topic; idempotent ensure paths for function and Eventarc.

## Test plan

- [x] Unit tests: `tests/infrastructure/gcp/test_eventarc.py`, `test_function.py`, `test_pub_sub.py`, `test_infra_ensure.py`
- [x] `aigear-infra --create` on a clean project (or after deleting Eventarc trigger only)
- [x] Confirm trigger and subscription exists.
- [x] aigear-infra --create after manually deleting topic/subscription/function (orphan trigger repair)
- [x] Publish via Cloud Scheduler (or manual publish); confirm messages reach the function and pipeline VMs start without duplicate inserts on redelivery

