### PR TITLE
Feature/ensure permissions to infras

### DIFF
--- a/src/aigear/infrastructure/gcp/infra.py
+++ b/src/aigear/infrastructure/gcp/infra.py
@@ -391,10 +391,9 @@ class Infra:
         if not exists:
             logger.info(
                 f"Service account ({self.aigear_config.gcp.iam.account_name}) not found in project "
-                f"({self.project_id}). Creating service account and binding IAM policies..."
+                f"({self.project_id}). Creating service account..."
             )
             self.service_accounts.create()
-            self.service_accounts.add_iam_policy_binding()
             logger.info(
                 f"Service account ({self.aigear_config.gcp.iam.account_name}) created successfully."
             )
@@ -403,6 +402,11 @@ class Infra:
                 f"Service account ({self.aigear_config.gcp.iam.account_name}) already exists in project "
                 f"({self.project_id}). Skipping creation."
             )
+        logger.info(
+            f"Binding IAM policies for service account ({self.aigear_config.gcp.iam.account_name})..."
+        )
+        self.service_accounts.add_iam_policy_binding()
+        logger.info("IAM policy binding complete.")
 
     def _ensure_model_bucket(self):
         exists = self.model_bucket.describe()
@@ -412,9 +416,6 @@ class Infra:
                 f"({self.location}). Creating bucket..."
             )
             self.model_bucket.create()
-            self.model_bucket.add_permissions_to_gcs(
-                sa_email=self.service_accounts.sa_email
-            )
             logger.info(
                 f"Model bucket ({self.aigear_config.gcp.bucket.bucket_name}) created successfully."
             )
@@ -423,6 +424,7 @@ class Infra:
                 f"Model bucket ({self.aigear_config.gcp.bucket.bucket_name}) already exists in location "
                 f"({self.location}). Skipping creation."
             )
+        self.model_bucket.add_permissions_to_gcs(sa_email=self.service_accounts.sa_email)
 
     def _ensure_release_bucket(self):
         exists = self.release_model_bucket.describe()
@@ -432,9 +434,6 @@ class Infra:
                 f"location ({self.location}). Creating bucket..."
             )
             self.release_model_bucket.create()
-            self.release_model_bucket.add_permissions_to_gcs(
-                sa_email=self.service_accounts.sa_email
-            )
             logger.info(
                 f"Release model bucket ({self.aigear_config.gcp.bucket.bucket_name_for_release}) created successfully."
             )
@@ -443,6 +442,7 @@ class Infra:
                 f"Release model bucket ({self.aigear_config.gcp.bucket.bucket_name_for_release}) already exists in "
                 f"location ({self.location}). Skipping creation."
             )
+        self.release_model_bucket.add_permissions_to_gcs(sa_email=self.service_accounts.sa_email)
 
     def _ensure_artifacts(self):
         exists = self.artifacts.describe()
@@ -469,9 +469,6 @@ class Infra:
                 f"({self.project_id}). Creating topic..."
             )
             self.pubsub.create()
-            self.pubsub.add_permissions_to_pubsub(
-                sa_email=self.service_accounts.sa_email
-            )
             logger.info(
                 f"Pub/Sub topic ({self.aigear_config.gcp.pub_sub.topic_name}) created successfully."
             )
@@ -480,6 +477,7 @@ class Infra:
                 f"Pub/Sub topic ({self.aigear_config.gcp.pub_sub.topic_name}) already exists in project "
                 f"({self.project_id}). Skipping creation."
             )
+        self.pubsub.add_permissions_to_pubsub(sa_email=self.service_accounts.sa_email)
 
     def _ensure_kms(self):
         if not self.cloud_kms.describe_keyring():
@@ -502,7 +500,6 @@ class Infra:
                 f"KMS key ({self.aigear_config.gcp.kms.key_name}) not found. Creating key..."
             )
             self.cloud_kms.create_key()
-            self.cloud_kms.add_permissions(sa_email=self.service_account)
             logger.info(
                 f"KMS key ({self.aigear_config.gcp.kms.key_name}) created successfully."
             )
@@ -519,6 +516,7 @@ class Infra:
             logger.info(
                 f"KMS key ({self.aigear_config.gcp.kms.key_name}) already exists. Skipping creation."
             )
+        self.cloud_kms.add_permissions(sa_email=self.service_account)
 
     def _ensure_cloud_build(self):
         exists = self.cloud_build.describe()
@@ -560,17 +558,17 @@ class Infra:
                 f"({self.location}). Deploying Cloud Function..."
             )
             self.cloud_function.deploy()
-            self.cloud_function.add_permissions_to_cloud_function(
-                sa_email=self.service_accounts.sa_email
-            )
             logger.info(
                 f"Cloud Function ({self.aigear_config.gcp.cloud_function.function_name}) deployed successfully."
             )
         else:
             logger.info(
                 f"Cloud Function ({self.aigear_config.gcp.cloud_function.function_name}) already exists in region "
-                f"({self.location}). Skipping deployment."
+                f"({self.location})."
             )
+        self.cloud_function.add_permissions_to_cloud_function(
+            sa_email=self.service_accounts.sa_email
+        )
 
     def _ensure_pre_vm_image(self):
         from aigear.infrastructure.gcp.pre_vm_image import PreVMImage


### PR DESCRIPTION
  In infra.py, permission bindings were only applied inside the "resource does not exist" branch of each _ensure_* method. When a resource already existed, the entire else branch    simply logged a skip message without re-applying any IAM permissions.
                                                                                                                                                                                    
  This meant that on any run where resources were already present — such as re-running aigear-infra --create after a partial failure, adding a new service account to an existing
  environment, or restoring a deleted SA — all permission bindings between the service account and GCS buckets, Pub/Sub topics, KMS keys, and Cloud Functions were silently skipped.
   The infrastructure would appear healthy (no errors) but the service account would lack the permissions it needed at runtime.

  Fix

  Moved the permission binding calls outside the if not exists / else blocks in all six _ensure_* methods:

  - _ensure_service_account — add_iam_policy_binding() now always runs
  - _ensure_model_bucket — add_permissions_to_gcs() now always runs
  - _ensure_release_bucket — add_permissions_to_gcs() now always runs
  - _ensure_pubsub — add_permissions_to_pubsub() now always runs
  - _ensure_kms — add_permissions() now always runs
  - _ensure_cloud_function — add_permissions_to_cloud_function() now always runs

  Resource creation logic remains gated on existence checks. Only the permission step is unconditional. GCP add-iam-policy-binding is idempotent — binding an already-existing role
  has no side effects — so this change is safe for both fresh and pre-existing environments.